### PR TITLE
Redeem script tests refactor

### DIFF
--- a/lib/2wp-utils.js
+++ b/lib/2wp-utils.js
@@ -1,5 +1,5 @@
 const expect = require('chai').expect;
-const { sendFromCow, mineAndSync, sendTxWithCheck } = require('./rsk-utils');
+const { sendFromCow, mineAndSync, sendTxWithCheck, getUnlockedAddress } = require('./rsk-utils');
 const { wait, retryWithCheck } = require('./utils');
 const { getBridge, getLatestActiveForkName } = require('./precompiled-abi-forks-util');
 const { getBridgeState } = require('@rsksmart/bridge-state-data-parser');
@@ -250,11 +250,11 @@ const donateToBridge = async (rskTxHelper, btcTxHelper, donatingBtcAddressInform
  */
 const disableWhitelisting = async (rskTxHelper, btcTxHelper, blockDelay = 1) => {
     const bridge = getBridge(rskTxHelper.getClient());
-    const unlocked = await rskUtils.getUnlockedAddress(rskTxHelper, WHITELIST_CHANGE_PK, WHITELIST_CHANGE_ADDR);
+    const unlocked = await getUnlockedAddress(rskTxHelper, WHITELIST_CHANGE_PK, WHITELIST_CHANGE_ADDR);
     expect(unlocked).to.be.true;
     const disableLockWhitelistMethod = bridge.methods.setLockWhitelistDisableBlockDelay(blockDelay);
     const disableResultCallback = (disableResult) => expect(Number(disableResult)).to.equal(1);
-    await rskUtils.sendTxWithCheck(rskTxHelper, disableLockWhitelistMethod, WHITELIST_CHANGE_ADDR, disableResultCallback);
+    await sendTxWithCheck(rskTxHelper, disableLockWhitelistMethod, WHITELIST_CHANGE_ADDR, disableResultCallback);
     if(blockDelay > 0) {
       await btcTxHelper.mine(blockDelay);
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,5 @@
 var fs = require('fs-extra');
 var utils = require('peglib').utils;
-const bitcoin = require('peglib').bitcoin;
 const merkleLib = require('merkle-lib');
 const pmtBuilder = require('@rsksmart/pmt-builder');
 const bitcoinJs = require('bitcoinjs-lib');
@@ -13,7 +12,9 @@ var sequentialPromise = function(n, promiseReturn) {
 };
 
 const publicKeyToCompressed = function(publicKey) {
-  return bitcoin.keys.publicKeyToCompressed(publicKey);
+  return bitcoinJs.ECPair.fromPublicKey(Buffer.from(publicKey, 'hex'), { compressed: true })
+  .publicKey
+  .toString('hex');
 }
 
 var mapPromiseAll = function(map) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,6 @@
 var fs = require('fs-extra');
 var utils = require('peglib').utils;
+const bitcoin = require('peglib').bitcoin;
 const merkleLib = require('merkle-lib');
 const pmtBuilder = require('@rsksmart/pmt-builder');
 const bitcoinJs = require('bitcoinjs-lib');
@@ -10,6 +11,10 @@ var sequentialPromise = function(n, promiseReturn) {
   }
   return promiseReturn(n).then(() => sequentialPromise(n - 1, promiseReturn));
 };
+
+const publicKeyToCompressed = function(publicKey) {
+  return bitcoin.keys.publicKeyToCompressed(publicKey);
+}
 
 var mapPromiseAll = function(map) {
   var promises = Object.keys(map).map(key => map[key].then(result => ({ key, result })));
@@ -215,6 +220,7 @@ module.exports = {
   getRandomInt: getRandomInt,
   isPromise: utils.isPromise,
   interval: utils.interval,
+  publicKeyToCompressed,
   ensure0x: ensure0x,
   removeDir: removeDir,
   executeWithRetries: executeWithRetries,

--- a/tests/01_05_57-post_hop_active_powpeg_redeem_script.js
+++ b/tests/01_05_57-post_hop_active_powpeg_redeem_script.js
@@ -2,30 +2,44 @@ const chai = require('chai');
 chai.use(require('chai-as-promised'));
 const expect = chai.expect;
 
-const rsk = require('peglib').rsk;
 const redeemScriptParser = require('@rsksmart/powpeg-redeemscript-parser');
 const CustomError = require('../lib/CustomError');
-const removePrefix0x = require("../lib/utils").removePrefix0x;
-const { GENESIS_FEDERATION_ADDRESS, GENESIS_FEDERATION_REDEEM_SCRIPT } = require('../lib/constants');
-
+const removePrefix0x = require('../lib/utils').removePrefix0x;
+const {getRskTransactionHelpers} = require('../lib/rsk-tx-helper-provider');
+const {getBridge, getLatestActiveForkName} = require('../lib/precompiled-abi-forks-util');
+const {GENESIS_FEDERATION_ADDRESS, GENESIS_FEDERATION_REDEEM_SCRIPT} = require('../lib/constants');
+const {activateFork} = require('../lib/rsk-utils');
+/**
+ * Takes the blockchain to the required state for this test file to run in isolation.
+ */
+const fulfillRequirementsToRunAsSingleTestFile = async () => {
+  await activateFork(Runners.common.forks.hop400);
+};
 describe('Calling getActivePowpegRedeemScript method after hop', function() {
+  let rskTxHelpers;
+  let rskTxHelper;
+  let bridge;
+  before(async () => {
+    if (process.env.RUNNING_SINGLE_TEST_FILE) {
+      await fulfillRequirementsToRunAsSingleTestFile();
+    }
+    rskTxHelpers = getRskTransactionHelpers();
+    rskTxHelper = rskTxHelpers[0];
+    bridge = getBridge(rskTxHelper.getClient(), await getLatestActiveForkName());
+  });
 
-    before(() => {
-      rskClient = rsk.getClient(Runners.hosts.federate.host);
-    });
-  
-    it('should return the active powpeg redeem script', async () => {
-      try{
-        const activePowpegRedeemScript = await rskClient.rsk.bridge.methods.getActivePowpegRedeemScript().call();
-        const activeFederationAddressFromBridge = await rskClient.rsk.bridge.methods.getFederationAddress().call();
-        const addressFromRedeemScript = redeemScriptParser.getAddressFromRedeemScript(
-          'REGTEST', Buffer.from(removePrefix0x(activePowpegRedeemScript), 'hex')
-        );
-        
-        expect(activePowpegRedeemScript).to.eq(GENESIS_FEDERATION_REDEEM_SCRIPT);
-        expect(addressFromRedeemScript).to.eq(GENESIS_FEDERATION_ADDRESS).to.eq(activeFederationAddressFromBridge);
-      } catch (err) {
-        throw new CustomError('getActivePowpegRedeemScript method validation failure', err);
-      }
-    })
+  it('should return the active powpeg redeem script', async () => {
+    try {
+      const activePowpegRedeemScript = await bridge.methods.getActivePowpegRedeemScript().call();
+      const activeFederationAddressFromBridge = await bridge.methods.getFederationAddress().call();
+      const addressFromRedeemScript = redeemScriptParser.getAddressFromRedeemScript(
+          'REGTEST', Buffer.from(removePrefix0x(activePowpegRedeemScript), 'hex'),
+      );
+
+      expect(activePowpegRedeemScript).to.eq(GENESIS_FEDERATION_REDEEM_SCRIPT);
+      expect(addressFromRedeemScript).to.eq(GENESIS_FEDERATION_ADDRESS).to.eq(activeFederationAddressFromBridge);
+    } catch (err) {
+      throw new CustomError('getActivePowpegRedeemScript method validation failure', err);
+    }
+  });
 });

--- a/tests/03_02_01-last_fork_active_powpeg_redeem_script.js
+++ b/tests/03_02_01-last_fork_active_powpeg_redeem_script.js
@@ -7,6 +7,7 @@ const redeemScriptParser = require('@rsksmart/powpeg-redeemscript-parser');
 const CustomError = require('../lib/CustomError');
 const removePrefix0x = require("../lib/utils").removePrefix0x;
 const { GENESIS_FEDERATION_ADDRESS, GENESIS_FEDERATION_REDEEM_SCRIPT } = require('../lib/constants');
+let rskClient;
 
 describe('Calling getActivePowpegRedeemScript method after last fork before fedchange', function() {
 

--- a/tests/03_02_01-last_fork_active_powpeg_redeem_script.js
+++ b/tests/03_02_01-last_fork_active_powpeg_redeem_script.js
@@ -1,0 +1,31 @@
+const chai = require('chai');
+chai.use(require('chai-as-promised'));
+const expect = chai.expect;
+
+const rsk = require('peglib').rsk;
+const redeemScriptParser = require('@rsksmart/powpeg-redeemscript-parser');
+const CustomError = require('../lib/CustomError');
+const removePrefix0x = require("../lib/utils").removePrefix0x;
+const { GENESIS_FEDERATION_ADDRESS, GENESIS_FEDERATION_REDEEM_SCRIPT } = require('../lib/constants');
+
+describe('Calling getActivePowpegRedeemScript method after last fork before fedchange', function() {
+
+    before(() => {
+      rskClient = rsk.getClient(Runners.hosts.federate.host);
+    });
+  
+    it('should return the active powpeg redeem script', async () => {
+      try{
+        const activePowpegRedeemScript = await rskClient.rsk.bridge.methods.getActivePowpegRedeemScript().call();
+        const activeFederationAddressFromBridge = await rskClient.rsk.bridge.methods.getFederationAddress().call();
+        const addressFromRedeemScript = redeemScriptParser.getAddressFromRedeemScript(
+          'REGTEST', Buffer.from(removePrefix0x(activePowpegRedeemScript), 'hex')
+        );
+        
+        expect(activePowpegRedeemScript).to.eq(GENESIS_FEDERATION_REDEEM_SCRIPT);
+        expect(addressFromRedeemScript).to.eq(GENESIS_FEDERATION_ADDRESS).to.eq(activeFederationAddressFromBridge);
+      } catch (err) {
+        throw new CustomError('getActivePowpegRedeemScript method validation failure', err);
+      }
+    })
+});

--- a/tests/03_02_01-last_fork_active_powpeg_redeem_script.js
+++ b/tests/03_02_01-last_fork_active_powpeg_redeem_script.js
@@ -5,19 +5,16 @@ const redeemScriptParser = require('@rsksmart/powpeg-redeemscript-parser');
 const {getRskTransactionHelpers} = require('../lib/rsk-tx-helper-provider');
 const {getBridge, getLatestActiveForkName} = require('../lib/precompiled-abi-forks-util');
 const CustomError = require('../lib/CustomError');
-const {disableWhitelisting} = require('../lib/2wp-utils');
 const removePrefix0x = require('../lib/utils').removePrefix0x;
-const {getBtcClient} = require('../lib/btc-client-provider');
 const rskUtils = require('../lib/rsk-utils');
 const {
   GENESIS_FEDERATION_ADDRESS,
   GENESIS_FEDERATION_REDEEM_SCRIPT,
 } = require('../lib/constants');
 
-const fulfillRequirementsToRunAsSingleTestFile = async (rskTxHelper, btcTxHelper) => {
+const fulfillRequirementsToRunAsSingleTestFile = async () => {
   const latestForkName = rskUtils.getLatestForkName();
   await rskUtils.activateFork(latestForkName);
-  await disableWhitelisting(rskTxHelper, btcTxHelper);
 };
 
 describe('Calling getActivePowpegRedeemScript method after last fork before fedchange', function() {
@@ -26,12 +23,10 @@ describe('Calling getActivePowpegRedeemScript method after last fork before fedc
   let bridge;
 
   before(async () => {
-    const btcTxHelper = getBtcClient();
-
     rskTxHelpers = getRskTransactionHelpers();
     rskTxHelper = rskTxHelpers[0];
     if (process.env.RUNNING_SINGLE_TEST_FILE) {
-      await fulfillRequirementsToRunAsSingleTestFile(rskTxHelper, btcTxHelper);
+      await fulfillRequirementsToRunAsSingleTestFile();
     }
     bridge = getBridge(rskTxHelper.getClient(), await getLatestActiveForkName());
   });

--- a/tests/04_00_02-fedchange.js
+++ b/tests/04_00_02-fedchange.js
@@ -690,24 +690,6 @@ describe('RSK Federation change', function() {
     }
   });
 
-
-  it.skip('should return the active powpeg redeem script', async () => {
-    try{
-      const activePowpegRedeemScript = await rskClientNewFed.rsk.bridge.methods.getActivePowpegRedeemScript().call();
-      const activeFederationAddressFromBridge = await rskClientNewFed.rsk.bridge.methods.getFederationAddress().call();
-      const addressFromRedeemScript = redeemScriptParser.getAddressFromRedeemScript(
-        'REGTEST', Buffer.from(removePrefix0x(activePowpegRedeemScript), 'hex')
-      );
-      
-      expect(activePowpegRedeemScript).to.eq('0x' + p2shErpFedRedeemScript.toString('hex'));
-      expect(addressFromRedeemScript).to.eq(expectedNewFederationAddress).to.eq(activeFederationAddressFromBridge);
-    } catch (err) {
-      throw new CustomError('getActivePowpegRedeemScript method validation failure', err);
-    }
-  })
-
-
-
 });
 
 const getActiveFederationAddress = async() => {

--- a/tests/04_00_02-fedchange.js
+++ b/tests/04_00_02-fedchange.js
@@ -689,6 +689,25 @@ describe('RSK Federation change', function() {
       throw new CustomError('Transfer BTC to RBTC with outputs both federations failure', err);
     }
   });
+
+
+  it.skip('should return the active powpeg redeem script', async () => {
+    try{
+      const activePowpegRedeemScript = await rskClientNewFed.rsk.bridge.methods.getActivePowpegRedeemScript().call();
+      const activeFederationAddressFromBridge = await rskClientNewFed.rsk.bridge.methods.getFederationAddress().call();
+      const addressFromRedeemScript = redeemScriptParser.getAddressFromRedeemScript(
+        'REGTEST', Buffer.from(removePrefix0x(activePowpegRedeemScript), 'hex')
+      );
+      
+      expect(activePowpegRedeemScript).to.eq('0x' + p2shErpFedRedeemScript.toString('hex'));
+      expect(addressFromRedeemScript).to.eq(expectedNewFederationAddress).to.eq(activeFederationAddressFromBridge);
+    } catch (err) {
+      throw new CustomError('getActivePowpegRedeemScript method validation failure', err);
+    }
+  })
+
+
+
 });
 
 const getActiveFederationAddress = async() => {

--- a/tests/05_02_01-last_fork_active_powpeg_redeem_script.js
+++ b/tests/05_02_01-last_fork_active_powpeg_redeem_script.js
@@ -1,51 +1,114 @@
-const chai = require('chai');
-chai.use(require('chai-as-promised'));
+const chai = require("chai");
+chai.use(require("chai-as-promised"));
 const expect = chai.expect;
-const { compareFederateKeys } = require('../lib/federation-utils');
-const rsk = require('peglib').rsk;
-const redeemScriptParser = require('@rsksmart/powpeg-redeemscript-parser');
-const CustomError = require('../lib/CustomError');
+const peglib = require('peglib');
+const pegUtils = peglib.pegUtils;
+const bitcoin = peglib.bitcoin;
+const pegAssertions = require('../lib/assertions/2wp');
+const rskUtilsLegacy = require('../lib/rsk-utils-legacy');
+const rskUtils = require('../lib/rsk-utils');
+const { compareFederateKeys } = require("../lib/federation-utils");
+const { getRskTransactionHelpers } = require('../lib/rsk-tx-helper-provider');
+const rsk = require("peglib").rsk;
+const { getBtcClient } = require('../lib/btc-client-provider');
+const redeemScriptParser = require("@rsksmart/powpeg-redeemscript-parser");
+const CustomError = require("../lib/CustomError");
 const removePrefix0x = require("../lib/utils").removePrefix0x;
-const { 
-  ERP_PUBKEYS, 
+const {
+  ERP_PUBKEYS,
   ERP_CSV_VALUE,
-  INITIAL_FEDERATION_SIZE,
-  KEY_TYPE_BTC, 
-  KEY_TYPE_RSK, 
-  KEY_TYPE_MST
-} = require('../lib/constants');
-describe('Calling getActivePowpegRedeemScript method after last fork after fed change', function() {
+  KEY_TYPE_BTC,
+  KEY_TYPE_RSK,
+  KEY_TYPE_MST,
+} = require("../lib/constants");
+const INITIAL_FEDERATION_SIZE = 3;
+describe("Calling getActivePowpegRedeemScript method after last fork after fed change", function () {
+  before(() => {
+    rskClient = rsk.getClient(Runners.hosts.federate.host);
+  });
 
-    before(() => {
-      rskClient = rsk.getClient(Runners.hosts.federate.host);
-    });
-    
-    it('should return the active powpeg redeem script', async () => {
-      try{
-        const activePowpegRedeemScript = await rskClient.rsk.bridge.methods.getActivePowpegRedeemScript().call();
-        const activeFederationAddressFromBridge = await rskClient.rsk.bridge.methods.getFederationAddress().call();
-        const addressFromRedeemScript = redeemScriptParser.getAddressFromRedeemScript(
-          'REGTEST', Buffer.from(removePrefix0x(activePowpegRedeemScript), 'hex')
+  it("should return the active powpeg redeem script", async () => {
+    try {
+      const activePowpegRedeemScript = await rskClient.rsk.bridge.methods
+        .getActivePowpegRedeemScript()
+        .call();
+      const activeFederationAddressFromBridge =
+        await rskClient.rsk.bridge.methods.getFederationAddress().call();
+      const addressFromRedeemScript =
+        redeemScriptParser.getAddressFromRedeemScript(
+          "REGTEST",
+          Buffer.from(removePrefix0x(activePowpegRedeemScript), "hex")
         );
-        
-        newFederationPublicKeys = Runners.hosts.federates
+
+      rskClientOldFed = rsk.getClient(Runners.hosts.federate.host);
+
+      const NETWORK = bitcoin.networks.testnet;
+      btcClient = bitcoin.getClient(
+        Runners.hosts.bitcoin.rpcHost,
+        Runners.hosts.bitcoin.rpcUser,
+        Runners.hosts.bitcoin.rpcPassword,
+        NETWORK
+      );
+      rskClients = Runners.hosts.federates.map((federate) =>
+        rsk.getClient(federate.host)
+      );
+      rskTxHelpers = getRskTransactionHelpers();
+      rskTxHelper = rskTxHelpers[0];
+      btcTxHelper = getBtcClient();
+
+      if (process.env.RUNNING_SINGLE_TEST_FILE) {
+        await fulfillRequirementsToRunAsSingleTestFile(
+          rskTxHelper,
+          btcTxHelper
+        );
+      }
+
+      // Assume the last of the running federators belongs to the new federation
+      rskClientNewFed = rskClients[rskClients.length - 1];
+
+      rskClients = Runners.hosts.federates.map((federate) =>
+        rsk.getClient(federate.host)
+      );
+      // rskClientNewFed = rskClients[rskClients.length - 1];
+      newFederationPublicKeys = Runners.hosts.federates
         .filter((federate, index) => index >= INITIAL_FEDERATION_SIZE)
         .map((federate) => ({
-          [KEY_TYPE_BTC]: bitcoin.keys.publicKeyToCompressed(federate.publicKeys[KEY_TYPE_BTC]),
-          [KEY_TYPE_RSK]: bitcoin.keys.publicKeyToCompressed(federate.publicKeys[KEY_TYPE_RSK]),
-          [KEY_TYPE_MST]: bitcoin.keys.publicKeyToCompressed(federate.publicKeys[KEY_TYPE_MST])
+          [KEY_TYPE_BTC]: bitcoin.keys.publicKeyToCompressed(
+            federate.publicKeys[KEY_TYPE_BTC]
+          ),
+          [KEY_TYPE_RSK]: bitcoin.keys.publicKeyToCompressed(
+            federate.publicKeys[KEY_TYPE_RSK]
+          ),
+          [KEY_TYPE_MST]: bitcoin.keys.publicKeyToCompressed(
+            federate.publicKeys[KEY_TYPE_MST]
+          ),
         }))
         .sort(compareFederateKeys);
-        console.log("newFederationPublicKeys", newFederationPublicKeys)
-      newFederationBtcPublicKeys = newFederationPublicKeys.map(publicKeys => publicKeys[KEY_TYPE_BTC]);
+      newFederationBtcPublicKeys = newFederationPublicKeys.map(
+        (publicKeys) => publicKeys[KEY_TYPE_BTC]
+      );
+      const p2shErpFedRedeemScript = redeemScriptParser.getP2shErpRedeemScript(
+        newFederationBtcPublicKeys,
+        ERP_PUBKEYS,
+        ERP_CSV_VALUE
+      );
+      const expectedNewFederationAddress =
+        redeemScriptParser.getAddressFromRedeemScript(
+          "REGTEST",
+          p2shErpFedRedeemScript
+        );
 
-        const p2shErpFedRedeemScript = redeemScriptParser.getP2shErpRedeemScript(newFederationBtcPublicKeys, ERP_PUBKEYS, ERP_CSV_VALUE);
-        const expectedNewFederationAddress = redeemScriptParser.getAddressFromRedeemScript('REGTEST', p2shErpFedRedeemScript);
-
-        expect(activePowpegRedeemScript).to.eq('0x' + p2shErpFedRedeemScript.toString('hex'));
-        expect(addressFromRedeemScript).to.eq(expectedNewFederationAddress).to.eq(activeFederationAddressFromBridge);
-      } catch (err) {
-        throw new CustomError('getActivePowpegRedeemScript method validation failure', err);
-      }
-    })
+      expect(activePowpegRedeemScript)
+        .to.eq("0x" + p2shErpFedRedeemScript.toString("hex")
+      );
+      expect(addressFromRedeemScript)
+        .to.eq(expectedNewFederationAddress)
+        .to.eq(activeFederationAddressFromBridge);
+    } catch (err) {
+      throw new CustomError(
+        "getActivePowpegRedeemScript method validation failure",
+        err
+      );
+    }
+  });
 });

--- a/tests/05_02_01-last_fork_active_powpeg_redeem_script.js
+++ b/tests/05_02_01-last_fork_active_powpeg_redeem_script.js
@@ -70,9 +70,7 @@ describe('Calling getActivePowpegRedeemScript method after last fork after fed c
             p2shErpFedRedeemScript,
         );
 
-      expect(activePowpegRedeemScript)
-          .to.eq('0x' + p2shErpFedRedeemScript.toString('hex'),
-          );
+      expect(removePrefix0x(activePowpegRedeemScript)).to.eq(p2shErpFedRedeemScript.toString('hex'));
 
       
       expect(addressFromRedeemScript)

--- a/tests/05_02_01-last_fork_active_powpeg_redeem_script.js
+++ b/tests/05_02_01-last_fork_active_powpeg_redeem_script.js
@@ -1,115 +1,86 @@
-const chai = require("chai");
-chai.use(require("chai-as-promised"));
+const chai = require('chai');
+chai.use(require('chai-as-promised'));
 const expect = chai.expect;
 const peglib = require('peglib');
 const bitcoin = peglib.bitcoin;
-const { compareFederateKeys } = require("../lib/federation-utils");
-const { getRskTransactionHelpers } = require('../lib/rsk-tx-helper-provider');
-const rsk = require("peglib").rsk;
-const { getBtcClient } = require('../lib/btc-client-provider');
-const redeemScriptParser = require("@rsksmart/powpeg-redeemscript-parser");
-const CustomError = require("../lib/CustomError");
-const removePrefix0x = require("../lib/utils").removePrefix0x;
+const {compareFederateKeys} = require('../lib/federation-utils');
+const {getRskTransactionHelpers} = require('../lib/rsk-tx-helper-provider');
+const redeemScriptParser = require('@rsksmart/powpeg-redeemscript-parser');
+const CustomError = require('../lib/CustomError');
+const removePrefix0x = require('../lib/utils').removePrefix0x;
+const {getBridge, getLatestActiveForkName} = require('../lib/precompiled-abi-forks-util');
+
+// in order to run this as a single test file, it requires a federation change so follow the following command
+// npm run run-single-test-file 04_00_02-fedchange.js,05_02_01-last_fork_active_powpeg_redeem_script.js
+
 const {
   ERP_PUBKEYS,
   ERP_CSV_VALUE,
   KEY_TYPE_BTC,
   KEY_TYPE_RSK,
   KEY_TYPE_MST,
-} = require("../lib/constants");
+} = require('../lib/constants');
 const INITIAL_FEDERATION_SIZE = 3;
-let btcClient;
-let rskClientNewFed;
-let rskClients;
-let rskClient;
-let newFederationBtcPublicKeys;
-let newFederationPublicKeys;
+
 let rskTxHelpers;
-let btcTxHelper;
 let rskTxHelper;
-describe("Calling getActivePowpegRedeemScript method after last fork after fed change", function () {
-  before(() => {
-    rskClient = rsk.getClient(Runners.hosts.federate.host);
+let bridge;
+
+describe('Calling getActivePowpegRedeemScript method after last fork after fed change', function() {
+  before(async () => {
+    rskTxHelpers = getRskTransactionHelpers();
+    rskTxHelper = rskTxHelpers[0];
+    bridge = getBridge(rskTxHelper.getClient(), await getLatestActiveForkName());
   });
 
-  it("should return the active powpeg redeem script", async () => {
+  it('should return the active powpeg redeem script', async () => {
     try {
-      const activePowpegRedeemScript = await rskClient.rsk.bridge.methods
-        .getActivePowpegRedeemScript()
-        .call();
-      const activeFederationAddressFromBridge =
-        await rskClient.rsk.bridge.methods.getFederationAddress().call();
-      const addressFromRedeemScript =
-        redeemScriptParser.getAddressFromRedeemScript(
-          "REGTEST",
-          Buffer.from(removePrefix0x(activePowpegRedeemScript), "hex")
-        );
-
-      const NETWORK = bitcoin.networks.testnet;
-      btcClient = bitcoin.getClient(
-        Runners.hosts.bitcoin.rpcHost,
-        Runners.hosts.bitcoin.rpcUser,
-        Runners.hosts.bitcoin.rpcPassword,
-        NETWORK
+      const activePowpegRedeemScript = await bridge.methods
+          .getActivePowpegRedeemScript()
+          .call();
+      const activeFederationAddressFromBridge = await bridge.methods.getFederationAddress().call();
+      const addressFromRedeemScript = redeemScriptParser.getAddressFromRedeemScript(
+          'REGTEST',
+          Buffer.from(removePrefix0x(activePowpegRedeemScript), 'hex'),
       );
-      rskClients = Runners.hosts.federates.map((federate) =>
-        rsk.getClient(federate.host)
-      );
-      rskTxHelpers = getRskTransactionHelpers();
-      rskTxHelper = rskTxHelpers[0];
-      btcTxHelper = getBtcClient();
-
-      if (process.env.RUNNING_SINGLE_TEST_FILE) {
-        await fulfillRequirementsToRunAsSingleTestFile(
-          rskTxHelper,
-          btcTxHelper
-        );
-      }
-
-      // Assume the last of the running federators belongs to the new federation
-      rskClientNewFed = rskClients[rskClients.length - 1];
-
-      rskClients = Runners.hosts.federates.map((federate) =>
-        rsk.getClient(federate.host)
-      );
-      newFederationPublicKeys = Runners.hosts.federates
-        .filter((federate, index) => index >= INITIAL_FEDERATION_SIZE)
-        .map((federate) => ({
-          [KEY_TYPE_BTC]: bitcoin.keys.publicKeyToCompressed(
-            federate.publicKeys[KEY_TYPE_BTC]
-          ),
-          [KEY_TYPE_RSK]: bitcoin.keys.publicKeyToCompressed(
-            federate.publicKeys[KEY_TYPE_RSK]
-          ),
-          [KEY_TYPE_MST]: bitcoin.keys.publicKeyToCompressed(
-            federate.publicKeys[KEY_TYPE_MST]
-          ),
-        }))
-        .sort(compareFederateKeys);
-      newFederationBtcPublicKeys = newFederationPublicKeys.map(
-        (publicKeys) => publicKeys[KEY_TYPE_BTC]
+      const newFederationPublicKeys = Runners.hosts.federates
+          .filter((federate, index) => index >= INITIAL_FEDERATION_SIZE)
+          .map((federate) => ({
+            [KEY_TYPE_BTC]: bitcoin.keys.publicKeyToCompressed(
+                federate.publicKeys[KEY_TYPE_BTC],
+            ),
+            [KEY_TYPE_RSK]: bitcoin.keys.publicKeyToCompressed(
+                federate.publicKeys[KEY_TYPE_RSK],
+            ),
+            [KEY_TYPE_MST]: bitcoin.keys.publicKeyToCompressed(
+                federate.publicKeys[KEY_TYPE_MST],
+            ),
+          }))
+          .sort(compareFederateKeys);
+      const newFederationBtcPublicKeys = newFederationPublicKeys.map(
+          (publicKeys) => publicKeys[KEY_TYPE_BTC],
       );
       const p2shErpFedRedeemScript = redeemScriptParser.getP2shErpRedeemScript(
-        newFederationBtcPublicKeys,
-        ERP_PUBKEYS,
-        ERP_CSV_VALUE
+          newFederationBtcPublicKeys,
+          ERP_PUBKEYS,
+          ERP_CSV_VALUE,
       );
       const expectedNewFederationAddress =
         redeemScriptParser.getAddressFromRedeemScript(
-          "REGTEST",
-          p2shErpFedRedeemScript
+            'REGTEST',
+            p2shErpFedRedeemScript,
         );
 
       expect(activePowpegRedeemScript)
-        .to.eq("0x" + p2shErpFedRedeemScript.toString("hex")
-      );
+          .to.eq('0x' + p2shErpFedRedeemScript.toString('hex'),
+          );
       expect(addressFromRedeemScript)
-        .to.eq(expectedNewFederationAddress)
-        .to.eq(activeFederationAddressFromBridge);
+          .to.eq(expectedNewFederationAddress)
+          .to.eq(activeFederationAddressFromBridge);
     } catch (err) {
       throw new CustomError(
-        "getActivePowpegRedeemScript method validation failure",
-        err
+          'getActivePowpegRedeemScript method validation failure',
+          err,
       );
     }
   });

--- a/tests/05_02_01-last_fork_active_powpeg_redeem_script.js
+++ b/tests/05_02_01-last_fork_active_powpeg_redeem_script.js
@@ -1,0 +1,51 @@
+const chai = require('chai');
+chai.use(require('chai-as-promised'));
+const expect = chai.expect;
+const { compareFederateKeys } = require('../lib/federation-utils');
+const rsk = require('peglib').rsk;
+const redeemScriptParser = require('@rsksmart/powpeg-redeemscript-parser');
+const CustomError = require('../lib/CustomError');
+const removePrefix0x = require("../lib/utils").removePrefix0x;
+const { 
+  ERP_PUBKEYS, 
+  ERP_CSV_VALUE,
+  INITIAL_FEDERATION_SIZE,
+  KEY_TYPE_BTC, 
+  KEY_TYPE_RSK, 
+  KEY_TYPE_MST
+} = require('../lib/constants');
+describe('Calling getActivePowpegRedeemScript method after last fork after fed change', function() {
+
+    before(() => {
+      rskClient = rsk.getClient(Runners.hosts.federate.host);
+    });
+    
+    it('should return the active powpeg redeem script', async () => {
+      try{
+        const activePowpegRedeemScript = await rskClient.rsk.bridge.methods.getActivePowpegRedeemScript().call();
+        const activeFederationAddressFromBridge = await rskClient.rsk.bridge.methods.getFederationAddress().call();
+        const addressFromRedeemScript = redeemScriptParser.getAddressFromRedeemScript(
+          'REGTEST', Buffer.from(removePrefix0x(activePowpegRedeemScript), 'hex')
+        );
+        
+        newFederationPublicKeys = Runners.hosts.federates
+        .filter((federate, index) => index >= INITIAL_FEDERATION_SIZE)
+        .map((federate) => ({
+          [KEY_TYPE_BTC]: bitcoin.keys.publicKeyToCompressed(federate.publicKeys[KEY_TYPE_BTC]),
+          [KEY_TYPE_RSK]: bitcoin.keys.publicKeyToCompressed(federate.publicKeys[KEY_TYPE_RSK]),
+          [KEY_TYPE_MST]: bitcoin.keys.publicKeyToCompressed(federate.publicKeys[KEY_TYPE_MST])
+        }))
+        .sort(compareFederateKeys);
+        console.log("newFederationPublicKeys", newFederationPublicKeys)
+      newFederationBtcPublicKeys = newFederationPublicKeys.map(publicKeys => publicKeys[KEY_TYPE_BTC]);
+
+        const p2shErpFedRedeemScript = redeemScriptParser.getP2shErpRedeemScript(newFederationBtcPublicKeys, ERP_PUBKEYS, ERP_CSV_VALUE);
+        const expectedNewFederationAddress = redeemScriptParser.getAddressFromRedeemScript('REGTEST', p2shErpFedRedeemScript);
+
+        expect(activePowpegRedeemScript).to.eq('0x' + p2shErpFedRedeemScript.toString('hex'));
+        expect(addressFromRedeemScript).to.eq(expectedNewFederationAddress).to.eq(activeFederationAddressFromBridge);
+      } catch (err) {
+        throw new CustomError('getActivePowpegRedeemScript method validation failure', err);
+      }
+    })
+});

--- a/tests/05_02_01-last_fork_active_powpeg_redeem_script.js
+++ b/tests/05_02_01-last_fork_active_powpeg_redeem_script.js
@@ -21,6 +21,7 @@ const INITIAL_FEDERATION_SIZE = 3;
 let btcClient;
 let rskClientNewFed;
 let rskClients;
+let rskClient;
 let newFederationBtcPublicKeys;
 let newFederationPublicKeys;
 let rskTxHelpers;
@@ -71,7 +72,6 @@ describe("Calling getActivePowpegRedeemScript method after last fork after fed c
       rskClients = Runners.hosts.federates.map((federate) =>
         rsk.getClient(federate.host)
       );
-      // rskClientNewFed = rskClients[rskClients.length - 1];
       newFederationPublicKeys = Runners.hosts.federates
         .filter((federate, index) => index >= INITIAL_FEDERATION_SIZE)
         .map((federate) => ({

--- a/tests/05_02_01-last_fork_active_powpeg_redeem_script.js
+++ b/tests/05_02_01-last_fork_active_powpeg_redeem_script.js
@@ -2,11 +2,7 @@ const chai = require("chai");
 chai.use(require("chai-as-promised"));
 const expect = chai.expect;
 const peglib = require('peglib');
-const pegUtils = peglib.pegUtils;
 const bitcoin = peglib.bitcoin;
-const pegAssertions = require('../lib/assertions/2wp');
-const rskUtilsLegacy = require('../lib/rsk-utils-legacy');
-const rskUtils = require('../lib/rsk-utils');
 const { compareFederateKeys } = require("../lib/federation-utils");
 const { getRskTransactionHelpers } = require('../lib/rsk-tx-helper-provider');
 const rsk = require("peglib").rsk;
@@ -22,6 +18,14 @@ const {
   KEY_TYPE_MST,
 } = require("../lib/constants");
 const INITIAL_FEDERATION_SIZE = 3;
+let btcClient;
+let rskClientNewFed;
+let rskClients;
+let newFederationBtcPublicKeys;
+let newFederationPublicKeys;
+let rskTxHelpers;
+let btcTxHelper;
+let rskTxHelper;
 describe("Calling getActivePowpegRedeemScript method after last fork after fed change", function () {
   before(() => {
     rskClient = rsk.getClient(Runners.hosts.federate.host);
@@ -39,8 +43,6 @@ describe("Calling getActivePowpegRedeemScript method after last fork after fed c
           "REGTEST",
           Buffer.from(removePrefix0x(activePowpegRedeemScript), "hex")
         );
-
-      rskClientOldFed = rsk.getClient(Runners.hosts.federate.host);
 
       const NETWORK = bitcoin.networks.testnet;
       btcClient = bitcoin.getClient(

--- a/tests/05_02_01-last_fork_active_powpeg_redeem_script.js
+++ b/tests/05_02_01-last_fork_active_powpeg_redeem_script.js
@@ -1,13 +1,12 @@
 const chai = require('chai');
 chai.use(require('chai-as-promised'));
 const expect = chai.expect;
-const peglib = require('peglib');
-const bitcoin = peglib.bitcoin;
 const {compareFederateKeys} = require('../lib/federation-utils');
 const {getRskTransactionHelpers} = require('../lib/rsk-tx-helper-provider');
 const redeemScriptParser = require('@rsksmart/powpeg-redeemscript-parser');
 const CustomError = require('../lib/CustomError');
 const removePrefix0x = require('../lib/utils').removePrefix0x;
+const publicKeyToCompressed = require('../lib/utils').publicKeyToCompressed;
 const {getBridge, getLatestActiveForkName} = require('../lib/precompiled-abi-forks-util');
 
 // in order to run this as a single test file, it requires a federation change so follow the following command
@@ -46,15 +45,15 @@ describe('Calling getActivePowpegRedeemScript method after last fork after fed c
       const newFederationPublicKeys = Runners.hosts.federates
           .filter((federate, index) => index >= INITIAL_FEDERATION_SIZE)
           .map((federate) => ({
-            [KEY_TYPE_BTC]: bitcoin.keys.publicKeyToCompressed(
-                federate.publicKeys[KEY_TYPE_BTC],
-            ),
-            [KEY_TYPE_RSK]: bitcoin.keys.publicKeyToCompressed(
-                federate.publicKeys[KEY_TYPE_RSK],
-            ),
-            [KEY_TYPE_MST]: bitcoin.keys.publicKeyToCompressed(
-                federate.publicKeys[KEY_TYPE_MST],
-            ),
+            [KEY_TYPE_BTC]: publicKeyToCompressed(
+              federate.publicKeys[KEY_TYPE_BTC],
+          ),
+          [KEY_TYPE_RSK]: publicKeyToCompressed(
+              federate.publicKeys[KEY_TYPE_RSK],
+          ),
+          [KEY_TYPE_MST]: publicKeyToCompressed(
+              federate.publicKeys[KEY_TYPE_MST],
+          ),
           }))
           .sort(compareFederateKeys);
       const newFederationBtcPublicKeys = newFederationPublicKeys.map(
@@ -74,8 +73,11 @@ describe('Calling getActivePowpegRedeemScript method after last fork after fed c
       expect(activePowpegRedeemScript)
           .to.eq('0x' + p2shErpFedRedeemScript.toString('hex'),
           );
+
+      
       expect(addressFromRedeemScript)
-          .to.eq(expectedNewFederationAddress)
+          .to.eq(expectedNewFederationAddress);
+      expect(addressFromRedeemScript)    
           .to.eq(activeFederationAddressFromBridge);
     } catch (err) {
       throw new CustomError(


### PR DESCRIPTION
This PR introduces 2 new tests that is repeating the test for 01_05_57-post_hop_active_powpeg_redeem_script.js into 2 new files
03_02_01-last_fork_active_powpeg_redeem_script.js - validates that in the last fork activation the redeem script is correct.
05_02_01-last_fork_active_powpeg_redeem_script.js - validates that in the last fork activation and a federation change the redeem script is correct for the new federation.