### PR TITLE
Adds 'should do a basic legacy pegin with the value above minimum' test

### DIFF
--- a/lib/tests/2wp.js
+++ b/lib/tests/2wp.js
@@ -102,6 +102,48 @@ const execute = (description, getRskHost) => {
 
     });
 
+    it('should do a basic legacy pegin with the value above minimum', async () => {
+
+      // Arrange
+
+      const initialFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
+      const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
+      const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+      // Value above minimum
+      const peginValueInSatoshis = minimumPeginValueInSatoshis + Number(btcToSatoshis(0.1));
+
+      // Act
+
+      const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, satoshisToBtc(peginValueInSatoshis));
+      await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash);
+
+      // Assert
+
+      // The btc pegin tx is already marked as processed by the bridge
+      const isBtcTxHashAlreadyProcessed = await bridge.methods.isBtcTxHashAlreadyProcessed(btcPeginTxHash).call();
+      expect(isBtcTxHashAlreadyProcessed).to.be.true;
+
+      // The pegin_btc event is emitted with the expected values
+      const recipient1RskAddressChecksumed = rskTxHelper.getClient().utils.toChecksumAddress(ensure0x(senderRecipientInfo.rskRecipientRskAddressInfo.address));
+      const expectedEvent = createExpectedPeginBtcEvent(PEGIN_EVENTS.PEGIN_BTC, recipient1RskAddressChecksumed, btcPeginTxHash, peginValueInSatoshis);
+      const btcTxHashProcessedHeight = Number(await bridge.methods.getBtcTxHashProcessedHeight(btcPeginTxHash).call());
+      const peginBtcEvent = await findEventInBlock(rskTxHelper, expectedEvent.name, btcTxHashProcessedHeight);
+      expect(peginBtcEvent).to.be.deep.equal(expectedEvent);
+
+      // The federation balance is increased by the pegin value
+      const finalFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
+      expect(finalFederationAddressBalanceInSatoshis).to.be.equal(initialFederationAddressBalanceInSatoshis + peginValueInSatoshis);
+
+      // The sender address balance is decreased by the pegin value and the btc fee
+      const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+      expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
+
+      // The recipient rsk address balance is increased by the pegin value
+      const finalRskRecipientBalance = Number(await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address));
+      expect(finalRskRecipientBalance).to.be.equal(Number(satoshisToWeis(peginValueInSatoshis)));
+
+    });
+
   });
 
 }

--- a/lib/tests/2wp.js
+++ b/lib/tests/2wp.js
@@ -106,6 +106,8 @@ const execute = (description, getRskHost) => {
 
       // Arrange
 
+      const initialBridgeBalance = Number(await rskTxHelper.getBalance(BRIDGE_ADDRESS));
+      const initialBridgeUtxosBalance = await getBridgeUtxosBalance(rskTxHelper);
       const initialFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
       const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
       const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
@@ -141,6 +143,14 @@ const execute = (description, getRskHost) => {
       // The recipient rsk address balance is increased by the pegin value
       const finalRskRecipientBalance = Number(await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address));
       expect(finalRskRecipientBalance).to.be.equal(Number(satoshisToWeis(peginValueInSatoshis)));
+
+      // After the successful pegin, the Bridge balance should be reduced by the pegin value
+      const finalBridgeBalance = Number(await rskTxHelper.getBalance(BRIDGE_ADDRESS));
+      expect(finalBridgeBalance).to.be.equal(initialBridgeBalance - satoshisToWeis(peginValueInSatoshis));
+
+      // After the successful pegin, the Bridge utxos sum should be incremented by the pegin value
+      const finalBridgeUtxosBalance = await getBridgeUtxosBalance(rskTxHelper);
+      expect(finalBridgeUtxosBalance).to.be.equal(initialBridgeUtxosBalance + peginValueInSatoshis);
 
     });
 

--- a/lib/tests/2wp.js
+++ b/lib/tests/2wp.js
@@ -23,34 +23,6 @@ let federationAddress;
 let minimumPeginValueInSatoshis;
 let btcFeeInSatoshis;
 
-const assertExpectedPeginBtcEventIsEmitted = async (btcPeginTxHash, rskRecipientAddress, peginValueInSatoshis) => {
-  const recipient1RskAddressChecksumed = rskTxHelper.getClient().utils.toChecksumAddress(ensure0x(rskRecipientAddress));
-  const expectedEvent = createExpectedPeginBtcEvent(PEGIN_EVENTS.PEGIN_BTC, recipient1RskAddressChecksumed, btcPeginTxHash, peginValueInSatoshis);
-  const btcTxHashProcessedHeight = Number(await bridge.methods.getBtcTxHashProcessedHeight(btcPeginTxHash).call());
-  const peginBtcEvent = await findEventInBlock(rskTxHelper, expectedEvent.name, btcTxHashProcessedHeight);
-  expect(peginBtcEvent).to.be.deep.equal(expectedEvent);
-};
-
-/**
- * Gets the final 2wp balances (Federation, Bridge utxos and bridge rsk balances) and compares them to the `initial2wpBalances` to assert the expected values based on a successful pegin.
- * Checks that after a successful pegin, the federation and Bridge utxos balances are increased and the Bridge rsk balance is decreased, by the `peginValueInSatoshis` amount.
- * @param {{federationAddressBalanceInSatoshis: number, bridgeUtxosBalanceInSatoshis: number, bridgeBalanceInWeisBN: BN}} initial2wpBalances
- * @param {number} peginValueInSatoshis the value of the pegin in satoshis by which the 2wp balances are expected to be updated
- * @returns {Promise<void>}
- */
-const assert2wpBalancesAfterSuccessfulPegin = async (initial2wpBalances, peginValueInSatoshis) => {
-  
-  const final2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
-
-  expect(final2wpBalances.federationAddressBalanceInSatoshis).to.be.equal(initial2wpBalances.federationAddressBalanceInSatoshis + peginValueInSatoshis);
-
-  expect(final2wpBalances.bridgeUtxosBalanceInSatoshis).to.be.equal(initial2wpBalances.bridgeUtxosBalanceInSatoshis + peginValueInSatoshis);
-
-  const expectedFinalBridgeBalancesInWeisBN = initial2wpBalances.bridgeBalanceInWeisBN.sub(new BN(satoshisToWeis(peginValueInSatoshis)));
-  expect(final2wpBalances.bridgeBalanceInWeisBN.eq(expectedFinalBridgeBalancesInWeisBN)).to.be.true;
-
-};
-
 const execute = (description, getRskHost) => {
 
   describe(description, () => {
@@ -102,15 +74,15 @@ const execute = (description, getRskHost) => {
 
     });
 
-    it('should do a basic legacy pegin with the value above minimum', async () => {
+    it('should do a basic legacy pegin with the value exactly above minimum', async () => {
 
       // Arrange
 
-      const initial2wpBalances = await get2wpInitialBalances();
+      const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
       const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
       const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
-      // Value above minimum
-      const peginValueInSatoshis = minimumPeginValueInSatoshis + Number(btcToSatoshis(0.1));
+      // Value exactly above minimum
+      const peginValueInSatoshis = minimumPeginValueInSatoshis + 1;
 
       // Act
 
@@ -122,7 +94,7 @@ const execute = (description, getRskHost) => {
 
       await assertExpectedPeginBtcEventIsEmitted(btcPeginTxHash, senderRecipientInfo.rskRecipientRskAddressInfo.address, peginValueInSatoshis);
 
-      await assertSuccessfulPegin2wpFinalBalances(initial2wpBalances, peginValueInSatoshis);
+      await assert2wpBalancesAfterSuccessfulPegin(initial2wpBalances, peginValueInSatoshis);
 
       // The sender address balance is decreased by the pegin value and the btc fee
       const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
@@ -130,7 +102,7 @@ const execute = (description, getRskHost) => {
 
       // The recipient rsk address balance is increased by the pegin value
       const finalRskRecipientBalanceInWeisBN = await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address);
-      const expectedRskRecipientBalancesInWeisBN = rskTxHelper.getClient().utils.BN(satoshisToWeis(peginValueInSatoshis));
+      const expectedRskRecipientBalancesInWeisBN = new BN(satoshisToWeis(peginValueInSatoshis));
       expect(finalRskRecipientBalanceInWeisBN.eq(expectedRskRecipientBalancesInWeisBN)).to.be.true;
 
     });
@@ -138,6 +110,34 @@ const execute = (description, getRskHost) => {
   });
 
 }
+
+const assertExpectedPeginBtcEventIsEmitted = async (btcPeginTxHash, rskRecipientAddress, peginValueInSatoshis) => {
+  const recipient1RskAddressChecksumed = rskTxHelper.getClient().utils.toChecksumAddress(ensure0x(rskRecipientAddress));
+  const expectedEvent = createExpectedPeginBtcEvent(PEGIN_EVENTS.PEGIN_BTC, recipient1RskAddressChecksumed, btcPeginTxHash, peginValueInSatoshis);
+  const btcTxHashProcessedHeight = Number(await bridge.methods.getBtcTxHashProcessedHeight(btcPeginTxHash).call());
+  const peginBtcEvent = await findEventInBlock(rskTxHelper, expectedEvent.name, btcTxHashProcessedHeight);
+  expect(peginBtcEvent).to.be.deep.equal(expectedEvent);
+};
+
+/**
+ * Gets the final 2wp balances (Federation, Bridge utxos and bridge rsk balances) and compares them to the `initial2wpBalances` to assert the expected values based on a successful pegin.
+ * Checks that after a successful pegin, the federation and Bridge utxos balances are increased and the Bridge rsk balance is decreased, by the `peginValueInSatoshis` amount.
+ * @param {{federationAddressBalanceInSatoshis: number, bridgeUtxosBalanceInSatoshis: number, bridgeBalanceInWeisBN: BN}} initial2wpBalances
+ * @param {number} peginValueInSatoshis the value of the pegin in satoshis by which the 2wp balances are expected to be updated
+ * @returns {Promise<void>}
+ */
+const assert2wpBalancesAfterSuccessfulPegin = async (initial2wpBalances, peginValueInSatoshis) => {
+  
+  const final2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
+
+  expect(final2wpBalances.federationAddressBalanceInSatoshis).to.be.equal(initial2wpBalances.federationAddressBalanceInSatoshis + peginValueInSatoshis);
+
+  expect(final2wpBalances.bridgeUtxosBalanceInSatoshis).to.be.equal(initial2wpBalances.bridgeUtxosBalanceInSatoshis + peginValueInSatoshis);
+
+  const expectedFinalBridgeBalancesInWeisBN = initial2wpBalances.bridgeBalanceInWeisBN.sub(new BN(satoshisToWeis(peginValueInSatoshis)));
+  expect(final2wpBalances.bridgeBalanceInWeisBN.eq(expectedFinalBridgeBalancesInWeisBN)).to.be.true;
+
+};
 
 module.exports = {
   execute,

--- a/lib/tests/2wp.js
+++ b/lib/tests/2wp.js
@@ -106,9 +106,7 @@ const execute = (description, getRskHost) => {
 
       // Arrange
 
-      const initialBridgeBalance = Number(await rskTxHelper.getBalance(BRIDGE_ADDRESS));
-      const initialBridgeUtxosBalance = await getBridgeUtxosBalance(rskTxHelper);
-      const initialFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
+      const initial2wpBalances = await get2wpInitialBalances();
       const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
       const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
       // Value above minimum
@@ -117,40 +115,23 @@ const execute = (description, getRskHost) => {
       // Act
 
       const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, satoshisToBtc(peginValueInSatoshis));
-      await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash);
 
       // Assert
 
-      // The btc pegin tx is already marked as processed by the bridge
-      const isBtcTxHashAlreadyProcessed = await bridge.methods.isBtcTxHashAlreadyProcessed(btcPeginTxHash).call();
-      expect(isBtcTxHashAlreadyProcessed).to.be.true;
+      await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash);
 
-      // The pegin_btc event is emitted with the expected values
-      const recipient1RskAddressChecksumed = rskTxHelper.getClient().utils.toChecksumAddress(ensure0x(senderRecipientInfo.rskRecipientRskAddressInfo.address));
-      const expectedEvent = createExpectedPeginBtcEvent(PEGIN_EVENTS.PEGIN_BTC, recipient1RskAddressChecksumed, btcPeginTxHash, peginValueInSatoshis);
-      const btcTxHashProcessedHeight = Number(await bridge.methods.getBtcTxHashProcessedHeight(btcPeginTxHash).call());
-      const peginBtcEvent = await findEventInBlock(rskTxHelper, expectedEvent.name, btcTxHashProcessedHeight);
-      expect(peginBtcEvent).to.be.deep.equal(expectedEvent);
+      await assertExpectedPeginBtcEventIsEmitted(btcPeginTxHash, senderRecipientInfo.rskRecipientRskAddressInfo.address, peginValueInSatoshis);
 
-      // The federation balance is increased by the pegin value
-      const finalFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
-      expect(finalFederationAddressBalanceInSatoshis).to.be.equal(initialFederationAddressBalanceInSatoshis + peginValueInSatoshis);
+      await assertSuccessfulPegin2wpFinalBalances(initial2wpBalances, peginValueInSatoshis);
 
       // The sender address balance is decreased by the pegin value and the btc fee
       const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
       expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
 
       // The recipient rsk address balance is increased by the pegin value
-      const finalRskRecipientBalance = Number(await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address));
-      expect(finalRskRecipientBalance).to.be.equal(Number(satoshisToWeis(peginValueInSatoshis)));
-
-      // After the successful pegin, the Bridge balance should be reduced by the pegin value
-      const finalBridgeBalance = Number(await rskTxHelper.getBalance(BRIDGE_ADDRESS));
-      expect(finalBridgeBalance).to.be.equal(initialBridgeBalance - satoshisToWeis(peginValueInSatoshis));
-
-      // After the successful pegin, the Bridge utxos sum should be incremented by the pegin value
-      const finalBridgeUtxosBalance = await getBridgeUtxosBalance(rskTxHelper);
-      expect(finalBridgeUtxosBalance).to.be.equal(initialBridgeUtxosBalance + peginValueInSatoshis);
+      const finalRskRecipientBalanceInWeisBN = await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address);
+      const expectedRskRecipientBalancesInWeisBN = rskTxHelper.getClient().utils.BN(satoshisToWeis(peginValueInSatoshis));
+      expect(finalRskRecipientBalanceInWeisBN.eq(expectedRskRecipientBalancesInWeisBN)).to.be.true;
 
     });
 


### PR DESCRIPTION
Adds a basic legacy pegin test with a value above minimum.
Besides the value above minimum, this pegin does the same checks as this test in this pr: https://github.com/rsksmart/rootstock-integration-tests/pull/87