### PR TITLE
Adds legacy pegin test with multiple inputs from multiple accounts.

### DIFF
--- a/lib/2wp-utils.js
+++ b/lib/2wp-utils.js
@@ -244,7 +244,9 @@ const createSenderRecipientInfo = async (rskTxHelper, btcTxHelper, type = 'legac
     const rskRecipientRskAddressInfo = getDerivedRSKAddressInformation(btcSenderAddressInfo.privateKey, btcTxHelper.btcConfig.network);
     await rskTxHelper.importAccount(rskRecipientRskAddressInfo.privateKey);
     await rskTxHelper.unlockAccount(rskRecipientRskAddressInfo.address);
-    initialAmountToFundInBtc && await btcTxHelper.fundAddress(btcSenderAddressInfo.address, initialAmountToFundInBtc);
+    if(Number(initialAmountToFundInBtc) > 0) {
+        await btcTxHelper.fundAddress(btcSenderAddressInfo.address, initialAmountToFundInBtc);
+    }
     return {
         btcSenderAddressInfo,
         rskRecipientRskAddressInfo

--- a/lib/btc-utils.js
+++ b/lib/btc-utils.js
@@ -5,7 +5,6 @@ const { retryWithCheck } = require('./utils');
 const { getLogger } = require('../logger');
 const { btcToSatoshis } = require('@rsksmart/btc-eth-unit-converter');
 const BtcTransactionHelper = require('btc-transaction-helper/btc-transaction-helper');
-const SpendableUtxosInformation = require('btc-transaction-helper');
 
 const logger = getLogger();
 
@@ -188,19 +187,6 @@ const waitForBitcoinMempoolToGetTxs = async (btcTxHelper, maxAttempts = 3, check
     return Number(btcToSatoshis(await btcTxHelper.getAddressBalance(btcAddress)));
   };
 
-  /**
-   * Gets the list of utxos that sum up to the `amountInBtc` for the given btc address, and includes the calculated change.
-   * Once the sum of the selected utxos is equal o greater than the `amountInBtc`, no more utxos will be added.
-   * This doesn't return the list of utxos from the account, only utxos that sum up to `amountInBtc`.
-   * @param {BtcTransactionHelper} btcTxHelper to make calls in the bitcoin network
-   * @param {string} address the btc account address to get the utxos from
-   * @param {number} amountInBtc the amount in btc the utxos need to sum up to
-   * @returns {Promise<import('btc-transaction-helper').SpendableUtxosInformation>} an object containing the list of `utxos` and the `change` difference of the sum of utxos minus the `amountInBtc`
-   */
-  const getAddressUtxosInfo = async (btcTxHelper, address, amountInBtc) => {
-    return await btcTxHelper.selectSpendableUTXOsFromAddress(address, amountInBtc);
-  };
-
   module.exports = {
     publicKeyToCompressed,
     fundAddressAndGetData,
@@ -208,5 +194,4 @@ const waitForBitcoinMempoolToGetTxs = async (btcTxHelper, maxAttempts = 3, check
     waitForBitcoinTxToBeInMempool,
     waitForBitcoinMempoolToGetTxs,
     getBtcAddressBalanceInSatoshis,
-    getAddressUtxosInfo,
   };

--- a/lib/btc-utils.js
+++ b/lib/btc-utils.js
@@ -4,6 +4,8 @@ const pmtBuilder = require('@rsksmart/pmt-builder');
 const { retryWithCheck } = require('./utils');
 const { getLogger } = require('../logger');
 const { btcToSatoshis } = require('@rsksmart/btc-eth-unit-converter');
+const BtcTransactionHelper = require('btc-transaction-helper/btc-transaction-helper');
+const SpendableUtxosInformation = require('btc-transaction-helper');
 
 const logger = getLogger();
 
@@ -184,7 +186,20 @@ const waitForBitcoinMempoolToGetTxs = async (btcTxHelper, maxAttempts = 3, check
 
   const getBtcAddressBalanceInSatoshis = async (btcTxHelper, btcAddress) => {
     return Number(btcToSatoshis(await btcTxHelper.getAddressBalance(btcAddress)));
-  };  
+  };
+
+  /**
+   * Gets the list of utxos that sum up to the `amountInBtc` for the given btc address, and includes the calculated change.
+   * Once the sum of the selected utxos is equal o greater than the `amountInBtc`, no more utxos will be added.
+   * This doesn't return the list of utxos from the account, only utxos that sum up to `amountInBtc`.
+   * @param {BtcTransactionHelper} btcTxHelper to make calls in the bitcoin network
+   * @param {string} address the btc account address to get the utxos from
+   * @param {number} amountInBtc the amount in btc the utxos need to sum up to
+   * @returns {Promise<import('btc-transaction-helper').SpendableUtxosInformation>} an object containing the list of `utxos` and the `change` difference of the sum of utxos minus the `amountInBtc`
+   */
+  const getAddressUtxosInfo = async (btcTxHelper, address, amountInBtc) => {
+    return await btcTxHelper.selectSpendableUTXOsFromAddress(address, amountInBtc);
+  };
 
   module.exports = {
     publicKeyToCompressed,
@@ -193,4 +208,5 @@ const waitForBitcoinMempoolToGetTxs = async (btcTxHelper, maxAttempts = 3, check
     waitForBitcoinTxToBeInMempool,
     waitForBitcoinMempoolToGetTxs,
     getBtcAddressBalanceInSatoshis,
-  }
+    getAddressUtxosInfo,
+  };

--- a/lib/tests/2wp.js
+++ b/lib/tests/2wp.js
@@ -13,7 +13,8 @@ const { sendPegin,
     get2wpBalances,
 } = require('../2wp-utils');
 const { ensure0x } = require('../utils');
-const { getBtcAddressBalanceInSatoshis } = require('../btc-utils');
+const { getBtcAddressBalanceInSatoshis, waitForBitcoinMempoolToGetTxs } = require('../btc-utils');
+const bitcoinJsLib = require('bitcoinjs-lib');
 
 let btcTxHelper;
 let rskTxHelper;
@@ -22,6 +23,38 @@ let bridge;
 let federationAddress;
 let minimumPeginValueInSatoshis;
 let btcFeeInSatoshis;
+
+const getSenderUtxosInfo = async (senderInfo, btcSenderAmountToSendToFed) => {
+  return await btcTxHelper.selectSpendableUTXOsFromAddress(senderInfo.btcSenderAddressInfo.address, btcSenderAmountToSendToFed);
+};
+
+const addInputs = (tx, senderUtxosInfo) => {
+  senderUtxosInfo.utxos.forEach(utxo => {
+    tx.addInput(Buffer.from(utxo.txid, 'hex').reverse(), utxo.vout);
+  });
+};
+
+const addChangeOutputs = (tx, changeAddress, changeInSatoshis) => {
+  if(changeInSatoshis > 0) {
+    tx.addOutput(
+      bitcoinJsLib.address.toOutputScript(changeAddress, btcTxHelper.btcConfig.network),
+      changeInSatoshis - btcFeeInSatoshis
+    );
+  }
+};
+
+const pushPegin = async (btcPeginTxHash, expectedUtxosCount = 1) => {
+  await waitForBitcoinMempoolToGetTxs(btcTxHelper, btcPeginTxHash);
+  await mineForPeginRegistration(rskTxHelper, btcTxHelper);
+  await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash, expectedUtxosCount);
+};
+
+const addOutputToFed = (tx, outputValueInSatoshis) => {
+  tx.addOutput(
+    bitcoinJsLib.address.toOutputScript(federationAddress, btcTxHelper.btcConfig.network),
+    outputValueInSatoshis
+  );
+};
 
 const execute = (description, getRskHost) => {
 
@@ -104,6 +137,84 @@ const execute = (description, getRskHost) => {
       const finalRskRecipientBalanceInWeisBN = await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address);
       const expectedRskRecipientBalancesInWeisBN = new BN(satoshisToWeis(peginValueInSatoshis));
       expect(finalRskRecipientBalanceInWeisBN.eq(expectedRskRecipientBalancesInWeisBN)).to.be.true;
+
+    });
+
+    it('should do legacy pegin with multiple inputs from different accounts and one output to the federation with value exactly minimum', async () => {
+
+      // Arrange
+
+      const initialFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
+      const sender1RecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
+      const sender2RecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
+      const initialSender1AddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, sender1RecipientInfo.btcSenderAddressInfo.address);
+      const initialSender2AddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, sender2RecipientInfo.btcSenderAddressInfo.address);
+
+      const sender1PeginValueInSatoshis = minimumPeginValueInSatoshis;
+      const sender2PeginValueInSatoshis = minimumPeginValueInSatoshis;
+      const peginValueInSatoshis = sender1PeginValueInSatoshis + sender2PeginValueInSatoshis;
+
+      const sender1UtxosInfo = await getSenderUtxosInfo(sender1RecipientInfo, satoshisToBtc(sender1PeginValueInSatoshis));
+      const sender2UtxosInfo = await getSenderUtxosInfo(sender2RecipientInfo, satoshisToBtc(sender2PeginValueInSatoshis));
+
+      const sender1ChangeInSatoshis = btcToSatoshis(sender1UtxosInfo.change);
+      const sender2ChangeInSatoshis = btcToSatoshis(sender2UtxosInfo.change);
+
+      const tx = new bitcoinJsLib.Transaction();
+
+      // Adding inputs
+      addInputs(tx, sender1UtxosInfo);
+      addInputs(tx, sender2UtxosInfo);
+
+      // Adding output to federation
+      addOutputToFed(tx, peginValueInSatoshis);
+
+      // Adding change outputs
+      addChangeOutputs(tx, sender1RecipientInfo.btcSenderAddressInfo.address, sender1ChangeInSatoshis);
+      addChangeOutputs(tx, sender2RecipientInfo.btcSenderAddressInfo.address, sender2ChangeInSatoshis);
+
+      // Signing the transaction
+      const sender1PrivateKey = sender1RecipientInfo.btcSenderAddressInfo.privateKey;
+      const sender2PrivateKey = sender2RecipientInfo.btcSenderAddressInfo.privateKey;
+      const sendersPrivateKeys = [sender1PrivateKey, sender2PrivateKey];
+      const signedTx = await btcTxHelper.nodeClient.signTransaction(tx.toHex(), [], sendersPrivateKeys);
+
+      // Act
+
+      // Sending the pegin and ensuring the pegin is registered
+      const btcPeginTxHash = await btcTxHelper.nodeClient.sendTransaction(signedTx);
+      await pushPegin(btcPeginTxHash);
+
+      // Assert
+
+      const isBtcTxHashAlreadyProcessed = await bridge.methods.isBtcTxHashAlreadyProcessed(btcPeginTxHash).call();
+      expect(isBtcTxHashAlreadyProcessed).to.be.true;
+
+      // The expected pegin_btc event should be emitted with the expected values
+      const recipient1RskAddressChecksumed = rskTxHelper.getClient().utils.toChecksumAddress(ensure0x(sender1RecipientInfo.rskRecipientRskAddressInfo.address));
+      const expectedEvent = createExpectedPeginBtcEvent(PEGIN_EVENTS.PEGIN_BTC, recipient1RskAddressChecksumed, btcPeginTxHash, peginValueInSatoshis);
+      const btcTxHashProcessedHeight = Number(await bridge.methods.getBtcTxHashProcessedHeight(btcPeginTxHash).call());
+      const peginBtcEvent = await findEventInBlock(rskTxHelper, expectedEvent.name, btcTxHashProcessedHeight);
+      expect(peginBtcEvent).to.be.deep.equal(expectedEvent);
+
+      // The federation address should have received the total amount sent by the senders
+      const finalFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
+      expect(finalFederationAddressBalanceInSatoshis).to.be.equal(initialFederationAddressBalanceInSatoshis + peginValueInSatoshis);
+
+      // The senders should have their balances reduced by the amount sent to the federation and the fee
+      const finalSender1AddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, sender1RecipientInfo.btcSenderAddressInfo.address);
+      expect(finalSender1AddressBalanceInSatoshis).to.be.equal(initialSender1AddressBalanceInSatoshis - sender1PeginValueInSatoshis - btcFeeInSatoshis);
+
+      const finalSender2AddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, sender2RecipientInfo.btcSenderAddressInfo.address);
+      expect(finalSender2AddressBalanceInSatoshis).to.be.equal(initialSender2AddressBalanceInSatoshis - sender2PeginValueInSatoshis - btcFeeInSatoshis);
+
+       // Only the first sender should have the total amount in rsk since in legacy pegins the rsk address is derived from the first input.
+      const finalRskRecipient1Balance = Number(await rskTxHelper.getBalance(sender1RecipientInfo.rskRecipientRskAddressInfo.address));
+      expect(finalRskRecipient1Balance).to.be.equal(Number(satoshisToWeis(peginValueInSatoshis)));
+
+      // Other senders should have 0 balance in rsk.
+      const finalRskRecipient2Balance = Number(await rskTxHelper.getBalance(sender2RecipientInfo.rskRecipientRskAddressInfo.address));
+      expect(finalRskRecipient2Balance).to.be.equal(0);
 
     });
 

--- a/lib/tests/2wp.js
+++ b/lib/tests/2wp.js
@@ -211,7 +211,7 @@ const execute = (description, getRskHost) => {
        // Only the first sender should have the total amount in rsk since in legacy pegins the rsk address is derived from the first input.
       const finalRskRecipient1BalanceInWeisBN = await rskTxHelper.getBalance(sender1RecipientInfo.rskRecipientRskAddressInfo.address);
       const expectedRskRecipient1BalanceInWeisBN = rskTxHelper.getClient().utils.BN(satoshisToWeis(peginValueInSatoshis));
-      expect(finalRskRecipient1BalanceInWeisBN).to.be.equal(expectedRskRecipient1BalanceInWeisBN);
+      expect(finalRskRecipient1BalanceInWeisBN.eq(expectedRskRecipient1BalanceInWeisBN)).to.be.true;
 
       // The second sender should have 0 balance in rsk.
       const finalRskRecipient2BalanceInWeisBN = Number(await rskTxHelper.getBalance(sender2RecipientInfo.rskRecipientRskAddressInfo.address));

--- a/lib/tests/2wp.js
+++ b/lib/tests/2wp.js
@@ -43,7 +43,7 @@ const addChangeOutputs = (tx, changeAddress, changeInSatoshis) => {
   }
 };
 
-const pushPegin = async (btcPeginTxHash, expectedUtxosCount = 1) => {
+const ensurePeginIsPushed = async (btcPeginTxHash, expectedUtxosCount = 1) => {
   await waitForBitcoinMempoolToGetTxs(btcTxHelper, btcPeginTxHash);
   await mineForPeginRegistration(rskTxHelper, btcTxHelper);
   await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash, expectedUtxosCount);
@@ -54,6 +54,18 @@ const addOutputToFed = (tx, outputValueInSatoshis) => {
     bitcoinJsLib.address.toOutputScript(federationAddress, btcTxHelper.btcConfig.network),
     outputValueInSatoshis
   );
+};
+
+/**
+ * Signs the btc transaction with the private keys of the senders
+ * @param {bitcoinJsLib.Transaction()} senderRecipientInfo 
+ * @param {...any} senderRecipientInfo 
+ * @returns {Promise<string>} the raw btc transaction in hex string
+ */
+const signPeginTransaction = async (tx, ...senderRecipientInfo) => {
+  const sendersPrivateKeys = senderRecipientInfo.map(senderRecipientInfo => senderRecipientInfo.btcSenderAddressInfo.privateKey);
+  const signedTx = await btcTxHelper.nodeClient.signTransaction(tx.toHex(), [], sendersPrivateKeys);
+  return signedTx;
 };
 
 const execute = (description, getRskHost) => {
@@ -144,9 +156,7 @@ const execute = (description, getRskHost) => {
 
       // Arrange
 
-      const initialBridgeBalanceInWeisBN = await rskTxHelper.getBalance(BRIDGE_ADDRESS);
-      const initialBridgeUtxosBalanceInSatoshis = await getBridgeUtxosBalance(rskTxHelper);
-      const initialFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
+      const initial2wpBalances = await get2wpInitialBalances();
       const sender1RecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
       const sender2RecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
       const initialSender1AddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, sender1RecipientInfo.btcSenderAddressInfo.address);
@@ -175,35 +185,23 @@ const execute = (description, getRskHost) => {
       addChangeOutputs(tx, sender1RecipientInfo.btcSenderAddressInfo.address, sender1ChangeInSatoshis);
       addChangeOutputs(tx, sender2RecipientInfo.btcSenderAddressInfo.address, sender2ChangeInSatoshis);
 
-      // Signing the transaction
-      const sender1PrivateKey = sender1RecipientInfo.btcSenderAddressInfo.privateKey;
-      const sender2PrivateKey = sender2RecipientInfo.btcSenderAddressInfo.privateKey;
-      const sendersPrivateKeys = [sender1PrivateKey, sender2PrivateKey];
-      const signedTx = await btcTxHelper.nodeClient.signTransaction(tx.toHex(), [], sendersPrivateKeys);
+      const signedTx = await signPeginTransaction(tx, sender1RecipientInfo, sender2RecipientInfo);
 
       // Act
 
       // Sending the pegin and ensuring the pegin is registered
       const btcPeginTxHash = await btcTxHelper.nodeClient.sendTransaction(signedTx);
-      await pushPegin(btcPeginTxHash);
 
       // Assert
 
-      const isBtcTxHashAlreadyProcessed = await bridge.methods.isBtcTxHashAlreadyProcessed(btcPeginTxHash).call();
-      expect(isBtcTxHashAlreadyProcessed).to.be.true;
+      // Since we are not using `sendPegin` here, we need to do some extra steps before ensuring the pegin is registered.
+      await ensurePeginIsPushed(btcPeginTxHash);
 
-      // The expected pegin_btc event should be emitted with the expected values
-      const recipient1RskAddressChecksumed = rskTxHelper.getClient().utils.toChecksumAddress(ensure0x(sender1RecipientInfo.rskRecipientRskAddressInfo.address));
-      const expectedEvent = createExpectedPeginBtcEvent(PEGIN_EVENTS.PEGIN_BTC, recipient1RskAddressChecksumed, btcPeginTxHash, peginValueInSatoshis);
-      const btcTxHashProcessedHeight = Number(await bridge.methods.getBtcTxHashProcessedHeight(btcPeginTxHash).call());
-      const peginBtcEvent = await findEventInBlock(rskTxHelper, expectedEvent.name, btcTxHashProcessedHeight);
-      expect(peginBtcEvent).to.be.deep.equal(expectedEvent);
+      await assertExpectedPeginBtcEventIsEmitted(btcPeginTxHash, sender1RecipientInfo.rskRecipientRskAddressInfo.address, peginValueInSatoshis);
 
-      // The federation address should have received the total amount sent by the senders
-      const finalFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
-      expect(finalFederationAddressBalanceInSatoshis).to.be.equal(initialFederationAddressBalanceInSatoshis + peginValueInSatoshis);
+      await assertSuccessfulPegin2wpFinalBalances(initial2wpBalances, peginValueInSatoshis);
 
-      // The senders should have their balances reduced by the amount sent to the federation and the fee
+      // The senders should have their balances reduced by the amount sent to the federation and the fee.
       const finalSender1AddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, sender1RecipientInfo.btcSenderAddressInfo.address);
       expect(finalSender1AddressBalanceInSatoshis).to.be.equal(initialSender1AddressBalanceInSatoshis - sender1PeginValueInSatoshis - btcFeeInSatoshis);
 
@@ -211,21 +209,13 @@ const execute = (description, getRskHost) => {
       expect(finalSender2AddressBalanceInSatoshis).to.be.equal(initialSender2AddressBalanceInSatoshis - sender2PeginValueInSatoshis - btcFeeInSatoshis);
 
        // Only the first sender should have the total amount in rsk since in legacy pegins the rsk address is derived from the first input.
-      const finalRskRecipient1Balance = Number(await rskTxHelper.getBalance(sender1RecipientInfo.rskRecipientRskAddressInfo.address));
-      expect(finalRskRecipient1Balance).to.be.equal(Number(satoshisToWeis(peginValueInSatoshis)));
+      const finalRskRecipient1BalanceInWeisBN = await rskTxHelper.getBalance(sender1RecipientInfo.rskRecipientRskAddressInfo.address);
+      const expectedRskRecipient1BalanceInWeisBN = rskTxHelper.getClient().utils.BN(satoshisToWeis(peginValueInSatoshis));
+      expect(finalRskRecipient1BalanceInWeisBN).to.be.equal(expectedRskRecipient1BalanceInWeisBN);
 
-      // Other senders should have 0 balance in rsk.
-      const finalRskRecipient2Balance = Number(await rskTxHelper.getBalance(sender2RecipientInfo.rskRecipientRskAddressInfo.address));
-      expect(finalRskRecipient2Balance).to.be.equal(0);
-
-      // After the successful pegin, the Bridge balance should be reduced by the pegin value
-      const finalBridgeBalanceInWeisBN = await rskTxHelper.getBalance(BRIDGE_ADDRESS);
-      const expectedPeginValueInWeisBN = initialBridgeBalanceInWeisBN.sub(rskTxHelper.getClient().utils.BN(`${satoshisToWeis(peginValueInSatoshis)}`));
-      expect(finalBridgeBalanceInWeisBN.eq(expectedPeginValueInWeisBN)).to.be.true;
-
-      // After the successful pegin, the Bridge utxos sum should be incremented by the pegin value
-      const finalBridgeUtxosBalance = await getBridgeUtxosBalance(rskTxHelper);
-      expect(finalBridgeUtxosBalance).to.be.equal(initialBridgeUtxosBalanceInSatoshis + peginValueInSatoshis);
+      // The second sender should have 0 balance in rsk.
+      const finalRskRecipient2BalanceInWeisBN = Number(await rskTxHelper.getBalance(sender2RecipientInfo.rskRecipientRskAddressInfo.address));
+      expect(finalRskRecipient2BalanceInWeisBN).to.be.equal(0);
 
     });
 

--- a/lib/tests/2wp.js
+++ b/lib/tests/2wp.js
@@ -13,7 +13,7 @@ const { sendPegin,
     get2wpBalances,
     mineForPeginRegistration,
 } = require('../2wp-utils');
-const { getBtcAddressBalanceInSatoshis, waitForBitcoinMempoolToGetTxs, getAddressUtxosInfo } = require('../btc-utils');
+const { getBtcAddressBalanceInSatoshis, waitForBitcoinMempoolToGetTxs } = require('../btc-utils');
 const { ensure0x } = require('../utils');
 const bitcoinJsLib = require('bitcoinjs-lib');
 
@@ -121,8 +121,8 @@ const execute = (description, getRskHost) => {
       const sender2PeginValueInSatoshis = minimumPeginValueInSatoshis;
       const peginValueInSatoshis = sender1PeginValueInSatoshis + sender2PeginValueInSatoshis;
 
-      const sender1UtxosInfo = await getAddressUtxosInfo(btcTxHelper, senderRecipientInfo1.btcSenderAddressInfo.address, satoshisToBtc(sender1PeginValueInSatoshis));
-      const sender2UtxosInfo = await getAddressUtxosInfo(btcTxHelper, senderRecipientInfo2.btcSenderAddressInfo.address, satoshisToBtc(sender2PeginValueInSatoshis));
+      const sender1UtxosInfo = await btcTxHelper.selectSpendableUTXOsFromAddress(senderRecipientInfo1.btcSenderAddressInfo.address, satoshisToBtc(sender1PeginValueInSatoshis));
+      const sender2UtxosInfo = await btcTxHelper.selectSpendableUTXOsFromAddress(senderRecipientInfo2.btcSenderAddressInfo.address, satoshisToBtc(sender2PeginValueInSatoshis));
 
       const sender1ChangeInSatoshis = btcToSatoshis(sender1UtxosInfo.change);
       const sender2ChangeInSatoshis = btcToSatoshis(sender2UtxosInfo.change);
@@ -130,15 +130,15 @@ const execute = (description, getRskHost) => {
       const tx = new bitcoinJsLib.Transaction();
 
       // Adding inputs
-      addInputs(tx, sender1UtxosInfo);
-      addInputs(tx, sender2UtxosInfo);
+      addInputs(tx, sender1UtxosInfo.utxos);
+      addInputs(tx, sender2UtxosInfo.utxos);
 
       // Adding output to federation
-      addOutputToFed(tx, peginValueInSatoshis);
+      addOutput(tx, federationAddress, peginValueInSatoshis);
 
       // Adding change outputs
-      addChangeOutputs(tx, senderRecipientInfo1.btcSenderAddressInfo.address, sender1ChangeInSatoshis);
-      addChangeOutputs(tx, senderRecipientInfo2.btcSenderAddressInfo.address, sender2ChangeInSatoshis);
+      addOutput(tx, senderRecipientInfo1.btcSenderAddressInfo.address, sender1ChangeInSatoshis - btcFeeInSatoshis);
+      addOutput(tx, senderRecipientInfo2.btcSenderAddressInfo.address, sender2ChangeInSatoshis - btcFeeInSatoshis);
 
       const sendersPrivateKeys = [senderRecipientInfo1.btcSenderAddressInfo.privateKey, senderRecipientInfo2.btcSenderAddressInfo.privateKey]
       const signedTx = await btcTxHelper.nodeClient.signTransaction(tx.toHex(), [], sendersPrivateKeys);
@@ -207,19 +207,10 @@ const assert2wpBalancesAfterSuccessfulPegin = async (initial2wpBalances, peginVa
 
 };
 
-const addInputs = (tx, senderUtxosInfo) => {
-  senderUtxosInfo.utxos.forEach(utxo => {
+const addInputs = (tx, utxos) => {
+  utxos.forEach(utxo => {
     tx.addInput(Buffer.from(utxo.txid, 'hex').reverse(), utxo.vout);
   });
-};
-
-const addChangeOutputs = (tx, changeAddress, changeInSatoshis) => {
-  if(changeInSatoshis > 0) {
-    tx.addOutput(
-      bitcoinJsLib.address.toOutputScript(changeAddress, btcTxHelper.btcConfig.network),
-      changeInSatoshis - btcFeeInSatoshis
-    );
-  }
 };
 
 const ensurePeginIsPushed = async (btcPeginTxHash, expectedUtxosCount = 1) => {
@@ -228,11 +219,13 @@ const ensurePeginIsPushed = async (btcPeginTxHash, expectedUtxosCount = 1) => {
   await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash, expectedUtxosCount);
 };
 
-const addOutputToFed = (tx, outputValueInSatoshis) => {
-  tx.addOutput(
-    bitcoinJsLib.address.toOutputScript(federationAddress, btcTxHelper.btcConfig.network),
-    outputValueInSatoshis
-  );
+const addOutput = (tx, address, outputValueInSatoshis) => {
+  if(outputValueInSatoshis > 0) {
+    tx.addOutput(
+      bitcoinJsLib.address.toOutputScript(address, btcTxHelper.btcConfig.network),
+      outputValueInSatoshis
+    );
+  }
 };
 
 module.exports = {

--- a/lib/tests/2wp.js
+++ b/lib/tests/2wp.js
@@ -2,7 +2,7 @@ const expect = require('chai').expect;
 const BN = require('bn.js');
 const { getBridge } = require('../precompiled-abi-forks-util');
 const { getBtcClient } = require('../btc-client-provider');
-const { getRskTransactionHelpers, getRskTransactionHelper } = require('../rsk-tx-helper-provider');
+const { getRskTransactionHelper } = require('../rsk-tx-helper-provider');
 const { satoshisToBtc, btcToSatoshis, satoshisToWeis } = require('@rsksmart/btc-eth-unit-converter');
 const { findEventInBlock } = require('../rsk-utils');
 const { PEGIN_EVENTS } = require("../constants");
@@ -11,62 +11,18 @@ const { sendPegin,
     createSenderRecipientInfo,
     createExpectedPeginBtcEvent,
     get2wpBalances,
+    mineForPeginRegistration,
 } = require('../2wp-utils');
+const { getBtcAddressBalanceInSatoshis, waitForBitcoinMempoolToGetTxs, getAddressUtxosInfo } = require('../btc-utils');
 const { ensure0x } = require('../utils');
-const { getBtcAddressBalanceInSatoshis, waitForBitcoinMempoolToGetTxs } = require('../btc-utils');
 const bitcoinJsLib = require('bitcoinjs-lib');
 
 let btcTxHelper;
 let rskTxHelper;
-let rskTxHelpers;
 let bridge;
 let federationAddress;
 let minimumPeginValueInSatoshis;
 let btcFeeInSatoshis;
-
-const getSenderUtxosInfo = async (senderInfo, btcSenderAmountToSendToFed) => {
-  return await btcTxHelper.selectSpendableUTXOsFromAddress(senderInfo.btcSenderAddressInfo.address, btcSenderAmountToSendToFed);
-};
-
-const addInputs = (tx, senderUtxosInfo) => {
-  senderUtxosInfo.utxos.forEach(utxo => {
-    tx.addInput(Buffer.from(utxo.txid, 'hex').reverse(), utxo.vout);
-  });
-};
-
-const addChangeOutputs = (tx, changeAddress, changeInSatoshis) => {
-  if(changeInSatoshis > 0) {
-    tx.addOutput(
-      bitcoinJsLib.address.toOutputScript(changeAddress, btcTxHelper.btcConfig.network),
-      changeInSatoshis - btcFeeInSatoshis
-    );
-  }
-};
-
-const ensurePeginIsPushed = async (btcPeginTxHash, expectedUtxosCount = 1) => {
-  await waitForBitcoinMempoolToGetTxs(btcTxHelper, btcPeginTxHash);
-  await mineForPeginRegistration(rskTxHelper, btcTxHelper);
-  await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash, expectedUtxosCount);
-};
-
-const addOutputToFed = (tx, outputValueInSatoshis) => {
-  tx.addOutput(
-    bitcoinJsLib.address.toOutputScript(federationAddress, btcTxHelper.btcConfig.network),
-    outputValueInSatoshis
-  );
-};
-
-/**
- * Signs the btc transaction with the private keys of the senders
- * @param {bitcoinJsLib.Transaction()} senderRecipientInfo 
- * @param {...any} senderRecipientInfo 
- * @returns {Promise<string>} the raw btc transaction in hex string
- */
-const signPeginTransaction = async (tx, ...senderRecipientInfo) => {
-  const sendersPrivateKeys = senderRecipientInfo.map(senderRecipientInfo => senderRecipientInfo.btcSenderAddressInfo.privateKey);
-  const signedTx = await btcTxHelper.nodeClient.signTransaction(tx.toHex(), [], sendersPrivateKeys);
-  return signedTx;
-};
 
 const execute = (description, getRskHost) => {
 
@@ -74,7 +30,6 @@ const execute = (description, getRskHost) => {
 
     before(async () => {
 
-      rskTxHelpers = getRskTransactionHelpers();
       btcTxHelper = getBtcClient();
       rskTxHelper = getRskTransactionHelper(getRskHost());
       bridge = getBridge(rskTxHelper.getClient());
@@ -156,18 +111,18 @@ const execute = (description, getRskHost) => {
 
       // Arrange
 
-      const initial2wpBalances = await get2wpInitialBalances();
-      const sender1RecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
-      const sender2RecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
-      const initialSender1AddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, sender1RecipientInfo.btcSenderAddressInfo.address);
-      const initialSender2AddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, sender2RecipientInfo.btcSenderAddressInfo.address);
+      const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
+      const senderRecipientInfo1 = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
+      const senderRecipientInfo2 = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
+      const initialSender1AddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo1.btcSenderAddressInfo.address);
+      const initialSender2AddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo2.btcSenderAddressInfo.address);
 
       const sender1PeginValueInSatoshis = minimumPeginValueInSatoshis;
       const sender2PeginValueInSatoshis = minimumPeginValueInSatoshis;
       const peginValueInSatoshis = sender1PeginValueInSatoshis + sender2PeginValueInSatoshis;
 
-      const sender1UtxosInfo = await getSenderUtxosInfo(sender1RecipientInfo, satoshisToBtc(sender1PeginValueInSatoshis));
-      const sender2UtxosInfo = await getSenderUtxosInfo(sender2RecipientInfo, satoshisToBtc(sender2PeginValueInSatoshis));
+      const sender1UtxosInfo = await getAddressUtxosInfo(btcTxHelper, senderRecipientInfo1.btcSenderAddressInfo.address, satoshisToBtc(sender1PeginValueInSatoshis));
+      const sender2UtxosInfo = await getAddressUtxosInfo(btcTxHelper, senderRecipientInfo2.btcSenderAddressInfo.address, satoshisToBtc(sender2PeginValueInSatoshis));
 
       const sender1ChangeInSatoshis = btcToSatoshis(sender1UtxosInfo.change);
       const sender2ChangeInSatoshis = btcToSatoshis(sender2UtxosInfo.change);
@@ -182,10 +137,11 @@ const execute = (description, getRskHost) => {
       addOutputToFed(tx, peginValueInSatoshis);
 
       // Adding change outputs
-      addChangeOutputs(tx, sender1RecipientInfo.btcSenderAddressInfo.address, sender1ChangeInSatoshis);
-      addChangeOutputs(tx, sender2RecipientInfo.btcSenderAddressInfo.address, sender2ChangeInSatoshis);
+      addChangeOutputs(tx, senderRecipientInfo1.btcSenderAddressInfo.address, sender1ChangeInSatoshis);
+      addChangeOutputs(tx, senderRecipientInfo2.btcSenderAddressInfo.address, sender2ChangeInSatoshis);
 
-      const signedTx = await signPeginTransaction(tx, sender1RecipientInfo, sender2RecipientInfo);
+      const sendersPrivateKeys = [senderRecipientInfo1.btcSenderAddressInfo.privateKey, senderRecipientInfo2.btcSenderAddressInfo.privateKey]
+      const signedTx = await btcTxHelper.nodeClient.signTransaction(tx.toHex(), [], sendersPrivateKeys);
 
       // Act
 
@@ -197,25 +153,25 @@ const execute = (description, getRskHost) => {
       // Since we are not using `sendPegin` here, we need to do some extra steps before ensuring the pegin is registered.
       await ensurePeginIsPushed(btcPeginTxHash);
 
-      await assertExpectedPeginBtcEventIsEmitted(btcPeginTxHash, sender1RecipientInfo.rskRecipientRskAddressInfo.address, peginValueInSatoshis);
+      await assertExpectedPeginBtcEventIsEmitted(btcPeginTxHash, senderRecipientInfo1.rskRecipientRskAddressInfo.address, peginValueInSatoshis);
 
-      await assertSuccessfulPegin2wpFinalBalances(initial2wpBalances, peginValueInSatoshis);
+      await assert2wpBalancesAfterSuccessfulPegin(initial2wpBalances, peginValueInSatoshis);
 
       // The senders should have their balances reduced by the amount sent to the federation and the fee.
-      const finalSender1AddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, sender1RecipientInfo.btcSenderAddressInfo.address);
+      const finalSender1AddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo1.btcSenderAddressInfo.address);
       expect(finalSender1AddressBalanceInSatoshis).to.be.equal(initialSender1AddressBalanceInSatoshis - sender1PeginValueInSatoshis - btcFeeInSatoshis);
 
-      const finalSender2AddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, sender2RecipientInfo.btcSenderAddressInfo.address);
+      const finalSender2AddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo2.btcSenderAddressInfo.address);
       expect(finalSender2AddressBalanceInSatoshis).to.be.equal(initialSender2AddressBalanceInSatoshis - sender2PeginValueInSatoshis - btcFeeInSatoshis);
 
        // Only the first sender should have the total amount in rsk since in legacy pegins the rsk address is derived from the first input.
-      const finalRskRecipient1BalanceInWeisBN = await rskTxHelper.getBalance(sender1RecipientInfo.rskRecipientRskAddressInfo.address);
+      const finalRskRecipient1BalanceInWeisBN = await rskTxHelper.getBalance(senderRecipientInfo1.rskRecipientRskAddressInfo.address);
       const expectedRskRecipient1BalanceInWeisBN = rskTxHelper.getClient().utils.BN(satoshisToWeis(peginValueInSatoshis));
       expect(finalRskRecipient1BalanceInWeisBN.eq(expectedRskRecipient1BalanceInWeisBN)).to.be.true;
 
       // The second sender should have 0 balance in rsk.
-      const finalRskRecipient2BalanceInWeisBN = Number(await rskTxHelper.getBalance(sender2RecipientInfo.rskRecipientRskAddressInfo.address));
-      expect(finalRskRecipient2BalanceInWeisBN).to.be.equal(0);
+      const finalRskRecipient2BalanceInWeisBN = await rskTxHelper.getBalance(senderRecipientInfo2.rskRecipientRskAddressInfo.address);
+      expect(finalRskRecipient2BalanceInWeisBN.eq(new BN('0'))).to.be.true;
 
     });
 
@@ -249,6 +205,34 @@ const assert2wpBalancesAfterSuccessfulPegin = async (initial2wpBalances, peginVa
   const expectedFinalBridgeBalancesInWeisBN = initial2wpBalances.bridgeBalanceInWeisBN.sub(new BN(satoshisToWeis(peginValueInSatoshis)));
   expect(final2wpBalances.bridgeBalanceInWeisBN.eq(expectedFinalBridgeBalancesInWeisBN)).to.be.true;
 
+};
+
+const addInputs = (tx, senderUtxosInfo) => {
+  senderUtxosInfo.utxos.forEach(utxo => {
+    tx.addInput(Buffer.from(utxo.txid, 'hex').reverse(), utxo.vout);
+  });
+};
+
+const addChangeOutputs = (tx, changeAddress, changeInSatoshis) => {
+  if(changeInSatoshis > 0) {
+    tx.addOutput(
+      bitcoinJsLib.address.toOutputScript(changeAddress, btcTxHelper.btcConfig.network),
+      changeInSatoshis - btcFeeInSatoshis
+    );
+  }
+};
+
+const ensurePeginIsPushed = async (btcPeginTxHash, expectedUtxosCount = 1) => {
+  await waitForBitcoinMempoolToGetTxs(btcTxHelper, btcPeginTxHash);
+  await mineForPeginRegistration(rskTxHelper, btcTxHelper);
+  await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash, expectedUtxosCount);
+};
+
+const addOutputToFed = (tx, outputValueInSatoshis) => {
+  tx.addOutput(
+    bitcoinJsLib.address.toOutputScript(federationAddress, btcTxHelper.btcConfig.network),
+    outputValueInSatoshis
+  );
 };
 
 module.exports = {

--- a/lib/tests/2wp.js
+++ b/lib/tests/2wp.js
@@ -144,6 +144,8 @@ const execute = (description, getRskHost) => {
 
       // Arrange
 
+      const initialBridgeBalanceInWeisBN = await rskTxHelper.getBalance(BRIDGE_ADDRESS);
+      const initialBridgeUtxosBalanceInSatoshis = await getBridgeUtxosBalance(rskTxHelper);
       const initialFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
       const sender1RecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
       const sender2RecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
@@ -215,6 +217,15 @@ const execute = (description, getRskHost) => {
       // Other senders should have 0 balance in rsk.
       const finalRskRecipient2Balance = Number(await rskTxHelper.getBalance(sender2RecipientInfo.rskRecipientRskAddressInfo.address));
       expect(finalRskRecipient2Balance).to.be.equal(0);
+
+      // After the successful pegin, the Bridge balance should be reduced by the pegin value
+      const finalBridgeBalanceInWeisBN = await rskTxHelper.getBalance(BRIDGE_ADDRESS);
+      const expectedPeginValueInWeisBN = initialBridgeBalanceInWeisBN.sub(rskTxHelper.getClient().utils.BN(`${satoshisToWeis(peginValueInSatoshis)}`));
+      expect(finalBridgeBalanceInWeisBN.eq(expectedPeginValueInWeisBN)).to.be.true;
+
+      // After the successful pegin, the Bridge utxos sum should be incremented by the pegin value
+      const finalBridgeUtxosBalance = await getBridgeUtxosBalance(rskTxHelper);
+      expect(finalBridgeUtxosBalance).to.be.equal(initialBridgeUtxosBalanceInSatoshis + peginValueInSatoshis);
 
     });
 


### PR DESCRIPTION
Adds 'should do legacy pegin with multiple inputs from different accounts and one output to the federation with value exactly minimum' test.

This tests what would happen if different bitcoin accounts create a pegin transaction where each of the inputs belong to a different account.

Asserts that the pegin is successful.

Asserts that the `pegin_btc` event is emitted with the expected values.

Asserts that only the first btc sender's input's derived rsk address is the one that receives the funds.