### PR TITLE
Adds 'should reject a basic pegin v1 with value exactly below minimum…

### DIFF
--- a/lib/tests/2wp.js
+++ b/lib/tests/2wp.js
@@ -256,7 +256,7 @@ const execute = (description, getRskHost) => {
       const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
       const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
       const peginValueInSatoshis = minimumPeginValueInSatoshis;
-      const peginV1RskRecipientAddress = await rskTxHelper.newAccountWithSeed('');
+      const peginV1RskRecipientAddress = await rskTxHelper.newAccountWithSeed('successfulPeginV1');
 
       // Act
 
@@ -331,81 +331,47 @@ const execute = (description, getRskHost) => {
 
     });
 
-    it('should do legacy pegin with multiple inputs from different accounts and one output to the federation with value exactly minimum', async () => {
+    it('should reject a basic pegin v1 with value exactly below minimum', async () => {
 
       // Arrange
 
-      const initialFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
-      const sender1RecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
-      const sender2RecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
-      const initialSender1AddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, sender1RecipientInfo.btcSenderAddressInfo.address);
-      const initialSender2AddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, sender2RecipientInfo.btcSenderAddressInfo.address);
-
-      const sender1PeginValueInSatoshis = minimumPeginValueInSatoshis;
-      const sender2PeginValueInSatoshis = minimumPeginValueInSatoshis;
-      const peginValueInSatoshis = sender1PeginValueInSatoshis + sender2PeginValueInSatoshis;
-
-      const sender1UtxosInfo = await getSenderUtxosInfo(sender1RecipientInfo, satoshisToBtc(sender1PeginValueInSatoshis));
-      const sender2UtxosInfo = await getSenderUtxosInfo(sender2RecipientInfo, satoshisToBtc(sender2PeginValueInSatoshis));
-
-      const sender1ChangeInSatoshis = btcToSatoshis(sender1UtxosInfo.change);
-      const sender2ChangeInSatoshis = btcToSatoshis(sender2UtxosInfo.change);
-
-      const tx = new bitcoinJsLib.Transaction();
-
-      // Adding inputs
-      addInputs(tx, sender1UtxosInfo);
-      addInputs(tx, sender2UtxosInfo);
-
-      // Adding output to federation
-      addOutputToFed(tx, peginValueInSatoshis);
-
-      // Adding change outputs
-      addChangeOutputs(tx, sender1RecipientInfo.btcSenderAddressInfo.address, sender1ChangeInSatoshis);
-      addChangeOutputs(tx, sender2RecipientInfo.btcSenderAddressInfo.address, sender2ChangeInSatoshis);
-
-      // Signing the transaction
-      const sender1PrivateKey = sender1RecipientInfo.btcSenderAddressInfo.privateKey;
-      const sender2PrivateKey = sender2RecipientInfo.btcSenderAddressInfo.privateKey;
-      const sendersPrivateKeys = [sender1PrivateKey, sender2PrivateKey];
-      const signedTx = await btcTxHelper.nodeClient.signTransaction(tx.toHex(), [], sendersPrivateKeys);
+      const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
+      const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
+      const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+      // The minimum pegin value minus 1 satoshis
+      const peginValueInSatoshis = minimumPeginValueInSatoshis - 1;
+      const peginV1RskRecipientAddress = await rskTxHelper.newAccountWithSeed('rejectedPeginV1');
 
       // Act
 
-      // Sending the pegin and ensuring the pegin is registered
-      const btcPeginTxHash = await btcTxHelper.nodeClient.sendTransaction(signedTx);
-      await pushPegin(btcPeginTxHash);
+      const peginV1Data = [Buffer.from(createPeginV1TxData(peginV1RskRecipientAddress), 'hex')];
+
+      const blockNumberBeforePegin = await rskTxHelper.getBlockNumber();
+
+      const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, satoshisToBtc(peginValueInSatoshis), peginV1Data);
+      // Funds of a pegin with value below minimum are lost. But calling triggerRelease here to ensure that nothing will be refunded.
+      await triggerRelease(rskTxHelpers, btcTxHelper);
 
       // Assert
 
-      const isBtcTxHashAlreadyProcessed = await bridge.methods.isBtcTxHashAlreadyProcessed(btcPeginTxHash).call();
-      expect(isBtcTxHashAlreadyProcessed).to.be.true;
+      // The btc pegin tx is not marked as processed by the bridge
+      await assertPeginTxHashNotProcessed(btcPeginTxHash);
 
-      // The expected pegin_btc event should be emitted with the expected values
-      const recipient1RskAddressChecksumed = rskTxHelper.getClient().utils.toChecksumAddress(ensure0x(sender1RecipientInfo.rskRecipientRskAddressInfo.address));
-      const expectedEvent = createExpectedPeginBtcEvent(PEGIN_EVENTS.PEGIN_BTC, recipient1RskAddressChecksumed, btcPeginTxHash, peginValueInSatoshis);
-      const btcTxHashProcessedHeight = Number(await bridge.methods.getBtcTxHashProcessedHeight(btcPeginTxHash).call());
-      const peginBtcEvent = await findEventInBlock(rskTxHelper, expectedEvent.name, btcTxHashProcessedHeight);
-      expect(peginBtcEvent).to.be.deep.equal(expectedEvent);
+      await assert2wpBalancesPeginRejectedBelowMinimum(initial2wpBalances, peginValueInSatoshis);
 
-      // The federation address should have received the total amount sent by the senders
-      const finalFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
-      expect(finalFederationAddressBalanceInSatoshis).to.be.equal(initialFederationAddressBalanceInSatoshis + peginValueInSatoshis);
+      await assertExpectedRejectedPeginEventIsEmitted(btcPeginTxHash, blockNumberBeforePegin, PEGIN_REJECTION_REASONS.INVALID_AMOUNT);
 
-      // The senders should have their balances reduced by the amount sent to the federation and the fee
-      const finalSender1AddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, sender1RecipientInfo.btcSenderAddressInfo.address);
-      expect(finalSender1AddressBalanceInSatoshis).to.be.equal(initialSender1AddressBalanceInSatoshis - sender1PeginValueInSatoshis - btcFeeInSatoshis);
+      // The sender address balance is decreased by the pegin value and the btc fee
+      const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+      expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
 
-      const finalSender2AddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, sender2RecipientInfo.btcSenderAddressInfo.address);
-      expect(finalSender2AddressBalanceInSatoshis).to.be.equal(initialSender2AddressBalanceInSatoshis - sender2PeginValueInSatoshis - btcFeeInSatoshis);
+      // The sender derived rsk address rsk address balance is unchanged
+      const finalSenderDerivedRskAddressBalance = Number(await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address));
+      expect(finalSenderDerivedRskAddressBalance).to.be.equal(0);
 
-       // Only the first sender should have the total amount in rsk since in legacy pegins the rsk address is derived from the first input.
-      const finalRskRecipient1Balance = Number(await rskTxHelper.getBalance(sender1RecipientInfo.rskRecipientRskAddressInfo.address));
-      expect(finalRskRecipient1Balance).to.be.equal(Number(satoshisToWeis(peginValueInSatoshis)));
-
-      // Other senders should have 0 balance in rsk.
-      const finalRskRecipient2Balance = Number(await rskTxHelper.getBalance(sender2RecipientInfo.rskRecipientRskAddressInfo.address));
-      expect(finalRskRecipient2Balance).to.be.equal(0);
+      // The pegin v1 rsk recipient address is also zero
+      const finalRskRecipientBalance = Number(await rskTxHelper.getBalance(peginV1RskRecipientAddress));
+      expect(finalRskRecipientBalance).to.be.equal(0);
 
     });
 
@@ -424,7 +390,9 @@ const assertExpectedPeginBtcEventIsEmitted = async (btcPeginTxHash, rskRecipient
 const assertExpectedRejectedPeginEventIsEmitted = async (btcPeginTxHash, blockNumberBeforePegin, rejectionReason) => {
   const expectedEvent = createExpectedRejectedPeginEvent(PEGIN_EVENTS.REJECTED_PEGIN, btcPeginTxHash, rejectionReason);
   const currentBlockNumber = await rskTxHelper.getBlockNumber();
-  const rejectedPeginEvent = await findEventInBlock(rskTxHelper, expectedEvent.name, blockNumberBeforePegin, currentBlockNumber);
+  const rejectedPeginEvent = await findEventInBlock(rskTxHelper, expectedEvent.name, blockNumberBeforePegin, currentBlockNumber, foundEvent => {
+    return foundEvent.arguments.btcTxHash === ensure0x(btcPeginTxHash);
+  });
   expect(rejectedPeginEvent).to.be.deep.equal(expectedEvent);
 };
 

--- a/lib/tests/2wp.js
+++ b/lib/tests/2wp.js
@@ -331,6 +331,84 @@ const execute = (description, getRskHost) => {
 
     });
 
+    it('should do legacy pegin with multiple inputs from different accounts and one output to the federation with value exactly minimum', async () => {
+
+      // Arrange
+
+      const initialFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
+      const sender1RecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
+      const sender2RecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
+      const initialSender1AddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, sender1RecipientInfo.btcSenderAddressInfo.address);
+      const initialSender2AddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, sender2RecipientInfo.btcSenderAddressInfo.address);
+
+      const sender1PeginValueInSatoshis = minimumPeginValueInSatoshis;
+      const sender2PeginValueInSatoshis = minimumPeginValueInSatoshis;
+      const peginValueInSatoshis = sender1PeginValueInSatoshis + sender2PeginValueInSatoshis;
+
+      const sender1UtxosInfo = await getSenderUtxosInfo(sender1RecipientInfo, satoshisToBtc(sender1PeginValueInSatoshis));
+      const sender2UtxosInfo = await getSenderUtxosInfo(sender2RecipientInfo, satoshisToBtc(sender2PeginValueInSatoshis));
+
+      const sender1ChangeInSatoshis = btcToSatoshis(sender1UtxosInfo.change);
+      const sender2ChangeInSatoshis = btcToSatoshis(sender2UtxosInfo.change);
+
+      const tx = new bitcoinJsLib.Transaction();
+
+      // Adding inputs
+      addInputs(tx, sender1UtxosInfo);
+      addInputs(tx, sender2UtxosInfo);
+
+      // Adding output to federation
+      addOutputToFed(tx, peginValueInSatoshis);
+
+      // Adding change outputs
+      addChangeOutputs(tx, sender1RecipientInfo.btcSenderAddressInfo.address, sender1ChangeInSatoshis);
+      addChangeOutputs(tx, sender2RecipientInfo.btcSenderAddressInfo.address, sender2ChangeInSatoshis);
+
+      // Signing the transaction
+      const sender1PrivateKey = sender1RecipientInfo.btcSenderAddressInfo.privateKey;
+      const sender2PrivateKey = sender2RecipientInfo.btcSenderAddressInfo.privateKey;
+      const sendersPrivateKeys = [sender1PrivateKey, sender2PrivateKey];
+      const signedTx = await btcTxHelper.nodeClient.signTransaction(tx.toHex(), [], sendersPrivateKeys);
+
+      // Act
+
+      // Sending the pegin and ensuring the pegin is registered
+      const btcPeginTxHash = await btcTxHelper.nodeClient.sendTransaction(signedTx);
+      await pushPegin(btcPeginTxHash);
+
+      // Assert
+
+      const isBtcTxHashAlreadyProcessed = await bridge.methods.isBtcTxHashAlreadyProcessed(btcPeginTxHash).call();
+      expect(isBtcTxHashAlreadyProcessed).to.be.true;
+
+      // The expected pegin_btc event should be emitted with the expected values
+      const recipient1RskAddressChecksumed = rskTxHelper.getClient().utils.toChecksumAddress(ensure0x(sender1RecipientInfo.rskRecipientRskAddressInfo.address));
+      const expectedEvent = createExpectedPeginBtcEvent(PEGIN_EVENTS.PEGIN_BTC, recipient1RskAddressChecksumed, btcPeginTxHash, peginValueInSatoshis);
+      const btcTxHashProcessedHeight = Number(await bridge.methods.getBtcTxHashProcessedHeight(btcPeginTxHash).call());
+      const peginBtcEvent = await findEventInBlock(rskTxHelper, expectedEvent.name, btcTxHashProcessedHeight);
+      expect(peginBtcEvent).to.be.deep.equal(expectedEvent);
+
+      // The federation address should have received the total amount sent by the senders
+      const finalFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
+      expect(finalFederationAddressBalanceInSatoshis).to.be.equal(initialFederationAddressBalanceInSatoshis + peginValueInSatoshis);
+
+      // The senders should have their balances reduced by the amount sent to the federation and the fee
+      const finalSender1AddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, sender1RecipientInfo.btcSenderAddressInfo.address);
+      expect(finalSender1AddressBalanceInSatoshis).to.be.equal(initialSender1AddressBalanceInSatoshis - sender1PeginValueInSatoshis - btcFeeInSatoshis);
+
+      const finalSender2AddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, sender2RecipientInfo.btcSenderAddressInfo.address);
+      expect(finalSender2AddressBalanceInSatoshis).to.be.equal(initialSender2AddressBalanceInSatoshis - sender2PeginValueInSatoshis - btcFeeInSatoshis);
+
+       // Only the first sender should have the total amount in rsk since in legacy pegins the rsk address is derived from the first input.
+      const finalRskRecipient1Balance = Number(await rskTxHelper.getBalance(sender1RecipientInfo.rskRecipientRskAddressInfo.address));
+      expect(finalRskRecipient1Balance).to.be.equal(Number(satoshisToWeis(peginValueInSatoshis)));
+
+      // Other senders should have 0 balance in rsk.
+      const finalRskRecipient2Balance = Number(await rskTxHelper.getBalance(sender2RecipientInfo.rskRecipientRskAddressInfo.address));
+      expect(finalRskRecipient2Balance).to.be.equal(0);
+
+    });
+
   });
 
 }


### PR DESCRIPTION
Adds 'should reject a basic pegin v1 with value exactly below minimum' test.

This test sends a pegin v1 with a value exactly below minimum (the minimum pegin value minus 1 satoshis), to assert that it should be rejected with rejection reason 5 (invalid amount).

Asserts that the sender funds are lost and that the sender's derived rsk address nor the pegin v1 rsk recipient address get any funds, but the federation balance is increased by the pegin amount while the Bridge doesn't mark that pegin tx as processed.
