### PR TITLE
Refactors federation and bridge balances checks and pegin btc event.

### DIFF
--- a/lib/2wp-utils.js
+++ b/lib/2wp-utils.js
@@ -182,7 +182,10 @@ const ensurePeginIsRegistered = async (rskTxHelper, peginBtcTxHash, expectedUtxo
 
     const { result: utxoIsRegisteredInTheBridge } = await retryWithCheck(method, check, MAX_ATTEMPTS, CHECK_EVERY_MILLISECONDS);
     
-    if(utxoIsRegisteredInTheBridge) {
+    const bridge = getBridge(rskTxHelper.getClient())
+    const isBtcTxHashAlreadyProcessed = await bridge.methods.isBtcTxHashAlreadyProcessed(peginBtcTxHash).call();
+    
+    if(utxoIsRegisteredInTheBridge && isBtcTxHashAlreadyProcessed) {
         logger.debug(`[${ensurePeginIsRegistered.name}] Found pegin ${peginBtcTxHash} registered in the bridge.`);
         // The pegin is already registered in the bridge, but the balance may still not be reflected on the user's rsk address
         // So we need to update the bridge and mine one more block so the balance is reflected on the user's rsk address

--- a/lib/2wp-utils.js
+++ b/lib/2wp-utils.js
@@ -8,7 +8,7 @@ const {
     waitAndUpdateBridge 
 } = require('./rsk-utils');
 const { retryWithCheck, ensure0x } = require('./utils');
-const { waitForBitcoinTxToBeInMempool, waitForBitcoinMempoolToGetTxs } = require('./btc-utils');
+const { waitForBitcoinTxToBeInMempool, waitForBitcoinMempoolToGetTxs, getBtcAddressBalanceInSatoshis } = require('./btc-utils');
 const { getBridge } = require('./precompiled-abi-forks-util');
 const { getBridgeState } = require('@rsksmart/bridge-state-data-parser');
 const { getDerivedRSKAddressInformation } = require('@rsksmart/btc-rsk-derivation');
@@ -282,7 +282,30 @@ const getBridgeUtxosBalance = async (rskTxHelper) => {
     const bridgeState = await getBridgeState(rskTxHelper.getClient());
     const utxosSum = bridgeState.activeFederationUtxos.reduce((sum, utxo) => sum + utxo.valueInSatoshis, 0);
     return utxosSum;
-};  
+};
+
+/**
+ * Gets the active Federation balance in satoshis, Bridge utxos balance in Satoshis and the Bridge rsk balance in weis BN (BigNumber)
+ * @param {RskTransactionHelper} rskTxHelper to make transactions to the rsk network
+ * @param {BtcTransactionHelper} btcTxHelper to make transactions to the bitcoin network
+ * @returns {Promise<{federationAddressBalanceInSatoshis: number, bridgeUtxosBalanceInSatoshis: number, bridgeBalanceInWeisBN: BN}>}
+ */
+const get2wpBalances = async (rskTxHelper, btcTxHelper) => {
+
+    const bridge = getBridge(rskTxHelper.getClient());
+    const federationAddress = await bridge.methods.getFederationAddress().call();
+
+    const federationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
+    const bridgeUtxosBalanceInSatoshis = await getBridgeUtxosBalance(rskTxHelper);
+    const bridgeBalanceInWeisBN = await rskTxHelper.getBalance(BRIDGE_ADDRESS);
+
+    return {
+      federationAddressBalanceInSatoshis,
+      bridgeUtxosBalanceInSatoshis,
+      bridgeBalanceInWeisBN,
+    };
+    
+};
 
 module.exports = {
     sendTxToBridge,
@@ -300,4 +323,5 @@ module.exports = {
     createSenderRecipientInfo,
     createExpectedPeginBtcEvent,
     getBridgeUtxosBalance,
+    get2wpBalances,
 };

--- a/lib/tests/2wp.js
+++ b/lib/tests/2wp.js
@@ -1,4 +1,5 @@
 const expect = require('chai').expect;
+const BN = require('bn.js');
 const { getBridge } = require('../precompiled-abi-forks-util');
 const { getBtcClient } = require('../btc-client-provider');
 const { getRskTransactionHelpers, getRskTransactionHelper } = require('../rsk-tx-helper-provider');
@@ -9,8 +10,7 @@ const { sendPegin,
     ensurePeginIsRegistered,
     createSenderRecipientInfo,
     createExpectedPeginBtcEvent,
-    BRIDGE_ADDRESS,
-    getBridgeUtxosBalance,
+    get2wpBalances,
 } = require('../2wp-utils');
 const { ensure0x } = require('../utils');
 const { getBtcAddressBalanceInSatoshis } = require('../btc-utils');
@@ -21,19 +21,7 @@ let rskTxHelpers;
 let bridge;
 let federationAddress;
 let minimumPeginValueInSatoshis;
-let minimumPeginValueInBtc;
 let btcFeeInSatoshis;
-
-const get2wpInitialBalances = async () => {
-  const initialBridgeBalanceInWeisBN = await rskTxHelper.getBalance(BRIDGE_ADDRESS);
-  const initialBridgeUtxosBalanceInSatoshis = await getBridgeUtxosBalance(rskTxHelper);
-  const initialFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
-  return {
-    initialBridgeBalanceInWeisBN,
-    initialBridgeUtxosBalanceInSatoshis,
-    initialFederationAddressBalanceInSatoshis,
-  };
-};
 
 const assertExpectedPeginBtcEventIsEmitted = async (btcPeginTxHash, rskRecipientAddress, peginValueInSatoshis) => {
   const recipient1RskAddressChecksumed = rskTxHelper.getClient().utils.toChecksumAddress(ensure0x(rskRecipientAddress));
@@ -43,23 +31,23 @@ const assertExpectedPeginBtcEventIsEmitted = async (btcPeginTxHash, rskRecipient
   expect(peginBtcEvent).to.be.deep.equal(expectedEvent);
 };
 
-const assertSuccessfulPegin2wpFinalBalances = async (initial2wpBalances, peginValueInSatoshis) => {
+/**
+ * Gets the final 2wp balances (Federation, Bridge utxos and bridge rsk balances) and compares them to the `initial2wpBalances` to assert the expected values based on a successful pegin.
+ * Checks that after a successful pegin, the federation and Bridge utxos balances are increased and the Bridge rsk balance is decreased, by the `peginValueInSatoshis` amount.
+ * @param {{federationAddressBalanceInSatoshis: number, bridgeUtxosBalanceInSatoshis: number, bridgeBalanceInWeisBN: BN}} initial2wpBalances
+ * @param {number} peginValueInSatoshis the value of the pegin in satoshis by which the 2wp balances are expected to be updated
+ * @returns {Promise<void>}
+ */
+const assert2wpBalancesAfterSuccessfulPegin = async (initial2wpBalances, peginValueInSatoshis) => {
+  
+  const final2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
 
-  const { initialBridgeBalanceInWeisBN, initialBridgeUtxosBalanceInSatoshis, initialFederationAddressBalanceInSatoshis } = initial2wpBalances;
+  expect(final2wpBalances.federationAddressBalanceInSatoshis).to.be.equal(initial2wpBalances.federationAddressBalanceInSatoshis + peginValueInSatoshis);
 
-  // The federation balance is increased by the pegin value
-  const finalFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
-  expect(finalFederationAddressBalanceInSatoshis).to.be.equal(initialFederationAddressBalanceInSatoshis + peginValueInSatoshis);
+  expect(final2wpBalances.bridgeUtxosBalanceInSatoshis).to.be.equal(initial2wpBalances.bridgeUtxosBalanceInSatoshis + peginValueInSatoshis);
 
-  // After the successful pegin, the Bridge balance should be reduced by the pegin value
-  const finalBridgeBalanceInWeisBN = await rskTxHelper.getBalance(BRIDGE_ADDRESS);
-  const peginValueInWeisBN = rskTxHelper.getClient().utils.BN(satoshisToWeis(peginValueInSatoshis));
-  const expectedFinalBridgeBalancesInWeisBN = initialBridgeBalanceInWeisBN.sub(peginValueInWeisBN);
-  expect(finalBridgeBalanceInWeisBN.eq(expectedFinalBridgeBalancesInWeisBN)).to.be.true;
-
-  // After the successful pegin, the Bridge utxos sum should be incremented by the pegin value
-  const finalBridgeUtxosBalance = await getBridgeUtxosBalance(rskTxHelper);
-  expect(finalBridgeUtxosBalance).to.be.equal(initialBridgeUtxosBalanceInSatoshis + peginValueInSatoshis);
+  const expectedFinalBridgeBalancesInWeisBN = initial2wpBalances.bridgeBalanceInWeisBN.sub(new BN(satoshisToWeis(peginValueInSatoshis)));
+  expect(final2wpBalances.bridgeBalanceInWeisBN.eq(expectedFinalBridgeBalancesInWeisBN)).to.be.true;
 
 };
 
@@ -76,7 +64,6 @@ const execute = (description, getRskHost) => {
 
       federationAddress = await bridge.methods.getFederationAddress().call();
       minimumPeginValueInSatoshis = Number(await bridge.methods.getMinimumLockTxValue().call());
-      minimumPeginValueInBtc = Number(satoshisToBtc(minimumPeginValueInSatoshis));
       btcFeeInSatoshis = btcToSatoshis(await btcTxHelper.getFee());
 
       await btcTxHelper.importAddress(federationAddress, 'federation');
@@ -87,7 +74,7 @@ const execute = (description, getRskHost) => {
 
       // Arrange
 
-      const initial2wpBalances = await get2wpInitialBalances();
+      const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
       const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
       const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
       const peginValueInSatoshis = minimumPeginValueInSatoshis;
@@ -102,7 +89,7 @@ const execute = (description, getRskHost) => {
 
       await assertExpectedPeginBtcEventIsEmitted(btcPeginTxHash, senderRecipientInfo.rskRecipientRskAddressInfo.address, peginValueInSatoshis);
 
-      await assertSuccessfulPegin2wpFinalBalances(initial2wpBalances, peginValueInSatoshis);
+      await assert2wpBalancesAfterSuccessfulPegin(initial2wpBalances, peginValueInSatoshis);
 
       // The btc sender address balance is decreased by the pegin value and the btc fee
       const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
@@ -110,7 +97,7 @@ const execute = (description, getRskHost) => {
 
       // The recipient rsk address balance is increased by the pegin value
       const finalRskRecipientBalanceInWeisBN = await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address);
-      const expectedRskRecipientBalancesInWeisBN = rskTxHelper.getClient().utils.BN(satoshisToWeis(peginValueInSatoshis));
+      const expectedRskRecipientBalancesInWeisBN = new BN(satoshisToWeis(peginValueInSatoshis));
       expect(finalRskRecipientBalanceInWeisBN.eq(expectedRskRecipientBalancesInWeisBN)).to.be.true;
 
     });

--- a/lib/tests/2wp.js
+++ b/lib/tests/2wp.js
@@ -107,7 +107,7 @@ const execute = (description, getRskHost) => {
       expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
 
       // The recipient rsk address balance is increased by the pegin value
-      const finalRskRecipientBalanceInWeisBN = Number(await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address));
+      const finalRskRecipientBalanceInWeisBN = await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address);
       const expectedRskRecipientBalancesInWeisBN = rskTxHelper.getClient().utils.BN(satoshisToWeis(peginValueInSatoshis));
       expect(finalRskRecipientBalanceInWeisBN.eq(expectedRskRecipientBalancesInWeisBN)).to.be.true;
 

--- a/lib/tests/2wp.js
+++ b/lib/tests/2wp.js
@@ -25,7 +25,7 @@ let minimumPeginValueInBtc;
 let btcFeeInSatoshis;
 
 const get2wpInitialBalances = async () => {
-  const initialBridgeBalanceInWeisBN = Number(await rskTxHelper.getBalance(BRIDGE_ADDRESS));
+  const initialBridgeBalanceInWeisBN = await rskTxHelper.getBalance(BRIDGE_ADDRESS);
   const initialBridgeUtxosBalanceInSatoshis = await getBridgeUtxosBalance(rskTxHelper);
   const initialFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
   return {
@@ -45,15 +45,17 @@ const assertExpectedPeginBtcEventIsEmitted = async (btcPeginTxHash, rskRecipient
 
 const assertSuccessfulPegin2wpFinalBalances = async (initial2wpBalances, peginValueInSatoshis) => {
 
-  const { initialBridgeBalanceInWeisBN, initialBridgeUtxosBalanceInSatoshis, initialFederationAddressBalanceInSatoshis } = initial2wpBalances
+  const { initialBridgeBalanceInWeisBN, initialBridgeUtxosBalanceInSatoshis, initialFederationAddressBalanceInSatoshis } = initial2wpBalances;
 
   // The federation balance is increased by the pegin value
   const finalFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
   expect(finalFederationAddressBalanceInSatoshis).to.be.equal(initialFederationAddressBalanceInSatoshis + peginValueInSatoshis);
 
   // After the successful pegin, the Bridge balance should be reduced by the pegin value
-  const finalBridgeBalance = Number(await rskTxHelper.getBalance(BRIDGE_ADDRESS));
-  expect(finalBridgeBalance).to.be.equal(initialBridgeBalanceInWeisBN - satoshisToWeis(peginValueInSatoshis));
+  const finalBridgeBalanceInWeisBN = await rskTxHelper.getBalance(BRIDGE_ADDRESS);
+  const peginValueInWeisBN = rskTxHelper.getClient().utils.BN(satoshisToWeis(peginValueInSatoshis));
+  const expectedFinalBridgeBalancesInWeisBN = initialBridgeBalanceInWeisBN.sub(peginValueInWeisBN);
+  expect(finalBridgeBalanceInWeisBN.eq(expectedFinalBridgeBalancesInWeisBN)).to.be.true;
 
   // After the successful pegin, the Bridge utxos sum should be incremented by the pegin value
   const finalBridgeUtxosBalance = await getBridgeUtxosBalance(rskTxHelper);

--- a/lib/tests/2wp.js
+++ b/lib/tests/2wp.js
@@ -24,6 +24,43 @@ let minimumPeginValueInSatoshis;
 let minimumPeginValueInBtc;
 let btcFeeInSatoshis;
 
+const get2wpInitialBalances = async () => {
+  const initialBridgeBalanceInWeisBN = Number(await rskTxHelper.getBalance(BRIDGE_ADDRESS));
+  const initialBridgeUtxosBalanceInSatoshis = await getBridgeUtxosBalance(rskTxHelper);
+  const initialFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
+  return {
+    initialBridgeBalanceInWeisBN,
+    initialBridgeUtxosBalanceInSatoshis,
+    initialFederationAddressBalanceInSatoshis,
+  };
+};
+
+const assertExpectedPeginBtcEventIsEmitted = async (btcPeginTxHash, rskRecipientAddress, peginValueInSatoshis) => {
+  const recipient1RskAddressChecksumed = rskTxHelper.getClient().utils.toChecksumAddress(ensure0x(rskRecipientAddress));
+  const expectedEvent = createExpectedPeginBtcEvent(PEGIN_EVENTS.PEGIN_BTC, recipient1RskAddressChecksumed, btcPeginTxHash, peginValueInSatoshis);
+  const btcTxHashProcessedHeight = Number(await bridge.methods.getBtcTxHashProcessedHeight(btcPeginTxHash).call());
+  const peginBtcEvent = await findEventInBlock(rskTxHelper, expectedEvent.name, btcTxHashProcessedHeight);
+  expect(peginBtcEvent).to.be.deep.equal(expectedEvent);
+};
+
+const assertSuccessfulPegin2wpFinalBalances = async (initial2wpBalances, peginValueInSatoshis) => {
+
+  const { initialBridgeBalanceInWeisBN, initialBridgeUtxosBalanceInSatoshis, initialFederationAddressBalanceInSatoshis } = initial2wpBalances
+
+  // The federation balance is increased by the pegin value
+  const finalFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
+  expect(finalFederationAddressBalanceInSatoshis).to.be.equal(initialFederationAddressBalanceInSatoshis + peginValueInSatoshis);
+
+  // After the successful pegin, the Bridge balance should be reduced by the pegin value
+  const finalBridgeBalance = Number(await rskTxHelper.getBalance(BRIDGE_ADDRESS));
+  expect(finalBridgeBalance).to.be.equal(initialBridgeBalanceInWeisBN - satoshisToWeis(peginValueInSatoshis));
+
+  // After the successful pegin, the Bridge utxos sum should be incremented by the pegin value
+  const finalBridgeUtxosBalance = await getBridgeUtxosBalance(rskTxHelper);
+  expect(finalBridgeUtxosBalance).to.be.equal(initialBridgeUtxosBalanceInSatoshis + peginValueInSatoshis);
+
+};
+
 const execute = (description, getRskHost) => {
 
   describe(description, () => {
@@ -48,9 +85,7 @@ const execute = (description, getRskHost) => {
 
       // Arrange
 
-      const initialBridgeBalance = Number(await rskTxHelper.getBalance(BRIDGE_ADDRESS));
-      const initialBridgeUtxosBalance = await getBridgeUtxosBalance(rskTxHelper);
-      const initialFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
+      const initial2wpBalances = await get2wpInitialBalances();
       const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
       const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
       const peginValueInSatoshis = minimumPeginValueInSatoshis;
@@ -58,40 +93,23 @@ const execute = (description, getRskHost) => {
       // Act
 
       const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, satoshisToBtc(peginValueInSatoshis));
-      await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash);
-
+      
       // Assert
 
-      // The btc pegin tx is already marked as processed by the bridge
-      const isBtcTxHashAlreadyProcessed = await bridge.methods.isBtcTxHashAlreadyProcessed(btcPeginTxHash).call();
-      expect(isBtcTxHashAlreadyProcessed).to.be.true;
+      await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash);
 
-      // The pegin_btc event is emitted with the expected values
-      const recipient1RskAddressChecksumed = rskTxHelper.getClient().utils.toChecksumAddress(ensure0x(senderRecipientInfo.rskRecipientRskAddressInfo.address));
-      const expectedEvent = createExpectedPeginBtcEvent(PEGIN_EVENTS.PEGIN_BTC, recipient1RskAddressChecksumed, btcPeginTxHash, peginValueInSatoshis);
-      const btcTxHashProcessedHeight = Number(await bridge.methods.getBtcTxHashProcessedHeight(btcPeginTxHash).call());
-      const peginBtcEvent = await findEventInBlock(rskTxHelper, expectedEvent.name, btcTxHashProcessedHeight);
-      expect(peginBtcEvent).to.be.deep.equal(expectedEvent);
+      await assertExpectedPeginBtcEventIsEmitted(btcPeginTxHash, senderRecipientInfo.rskRecipientRskAddressInfo.address, peginValueInSatoshis);
 
-      // The federation balance is increased by the pegin value
-      const finalFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
-      expect(finalFederationAddressBalanceInSatoshis).to.be.equal(initialFederationAddressBalanceInSatoshis + peginValueInSatoshis);
+      await assertSuccessfulPegin2wpFinalBalances(initial2wpBalances, peginValueInSatoshis);
 
-      // The sender address balance is decreased by the pegin value and the btc fee
+      // The btc sender address balance is decreased by the pegin value and the btc fee
       const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
       expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
 
       // The recipient rsk address balance is increased by the pegin value
-      const finalRskRecipientBalance = Number(await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address));
-      expect(finalRskRecipientBalance).to.be.equal(Number(satoshisToWeis(peginValueInSatoshis)));
-
-      // After the successful pegin, the Bridge balance should be reduced by the pegin value
-      const finalBridgeBalance = Number(await rskTxHelper.getBalance(BRIDGE_ADDRESS));
-      expect(finalBridgeBalance).to.be.equal(initialBridgeBalance - satoshisToWeis(peginValueInSatoshis));
-
-      // After the successful pegin, the Bridge utxos sum should be incremented by the pegin value
-      const finalBridgeUtxosBalance = await getBridgeUtxosBalance(rskTxHelper);
-      expect(finalBridgeUtxosBalance).to.be.equal(initialBridgeUtxosBalance + peginValueInSatoshis);
+      const finalRskRecipientBalanceInWeisBN = Number(await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address));
+      const expectedRskRecipientBalancesInWeisBN = rskTxHelper.getClient().utils.BN(satoshisToWeis(peginValueInSatoshis));
+      expect(finalRskRecipientBalanceInWeisBN.eq(expectedRskRecipientBalancesInWeisBN)).to.be.true;
 
     });
 


### PR DESCRIPTION
Takes the assertions of the federation and bridge balances to an utility function `assert2wpBalancesAfterSuccessfulPegin ` to reuse it and reduce complexity.
Takes the assertion of the expected pegin btc to an utility function `assertExpectedPeginBtcEventIsEmitted`.
Left these functions in the 2wp.js file since they make sense here and all pegins tests will be here.
Also adds a new `get2wpBalances` function in `2wp-utils.js` file, to get the federation, bridge utxos and bridge rsk balances.