### PR TITLE
Adds new peginv1 below minimum test

### DIFF
--- a/lib/tests/2wp.js
+++ b/lib/tests/2wp.js
@@ -117,7 +117,7 @@ const execute = (description, getRskHost) => {
       const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
       const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
       const peginValueInSatoshis = minimumPeginValueInSatoshis;
-      const peginV1RskRecipientAddress = await rskTxHelper.newAccountWithSeed('');
+      const peginV1RskRecipientAddress = await rskTxHelper.newAccountWithSeed('successfulPeginV1');
   
       // Act
   
@@ -192,6 +192,51 @@ const execute = (description, getRskHost) => {
 
     });
 
+    it('should reject a basic pegin v1 with value exactly below minimum', async () => {
+
+      // Arrange
+
+      const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
+      const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
+      const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+      // The minimum pegin value minus 1 satoshis
+      const peginValueInSatoshis = minimumPeginValueInSatoshis - 1;
+      
+      const peginV1RskRecipientAddress = await rskTxHelper.newAccountWithSeed('rejectedPeginV1');
+
+      // Act
+
+      const peginV1Data = [Buffer.from(createPeginV1TxData(peginV1RskRecipientAddress), 'hex')];
+
+      const blockNumberBeforePegin = await rskTxHelper.getBlockNumber();
+
+      const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, satoshisToBtc(peginValueInSatoshis), peginV1Data);
+      // Funds of a pegin with value below minimum are lost. But calling triggerRelease here to ensure that nothing will be refunded.
+      await triggerRelease(rskTxHelpers, btcTxHelper);
+
+      // Assert
+
+      // The btc pegin tx is not marked as processed by the bridge
+      await assertPeginTxHashNotProcessed(btcPeginTxHash);
+
+      await assert2wpBalancesPeginRejectedBelowMinimum(initial2wpBalances, peginValueInSatoshis);
+
+      await assertExpectedRejectedPeginEventIsEmitted(btcPeginTxHash, blockNumberBeforePegin, PEGIN_REJECTION_REASONS.INVALID_AMOUNT);
+
+      // The sender address balance is decreased by the pegin value and the btc fee
+      const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+      expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
+
+      // The sender derived rsk address rsk address balance is unchanged
+      const finalSenderDerivedRskAddressBalance = Number(await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address));
+      expect(finalSenderDerivedRskAddressBalance).to.be.equal(0);
+
+      // The pegin v1 rsk recipient address is also zero
+      const finalRskRecipientBalance = Number(await rskTxHelper.getBalance(peginV1RskRecipientAddress));
+      expect(finalRskRecipientBalance).to.be.equal(0);
+
+    });
+
   });
 
 };
@@ -227,7 +272,7 @@ const assert2wpBalancesAfterSuccessfulPegin = async (initial2wpBalances, peginVa
 const assertExpectedRejectedPeginEventIsEmitted = async (btcPeginTxHash, blockNumberBeforePegin, rejectionReason) => {
   const expectedEvent = createExpectedRejectedPeginEvent(btcPeginTxHash, rejectionReason);
   const currentBlockNumber = await rskTxHelper.getBlockNumber();
-  const rejectedPeginEvent = await findEventInBlock(rskTxHelper, expectedEvent.name, blockNumberBeforePegin, currentBlockNumber);
+  const rejectedPeginEvent = await findEventInBlock(rskTxHelper, expectedEvent.name, blockNumberBeforePegin, currentBlockNumber, foundEvent =>  foundEvent.arguments.btcTxHash === ensure0x(btcPeginTxHash));
   expect(rejectedPeginEvent).to.be.deep.equal(expectedEvent);
 };
 

--- a/lib/tests/2wp.js
+++ b/lib/tests/2wp.js
@@ -219,7 +219,7 @@ const execute = (description, getRskHost) => {
       // The btc pegin tx is not marked as processed by the bridge
       await assertPeginTxHashNotProcessed(btcPeginTxHash);
 
-      await assert2wpBalancesPeginRejectedBelowMinimum(initial2wpBalances, peginValueInSatoshis);
+      await assert2wpBalancesPeginRejectedNoRefund(initial2wpBalances, peginValueInSatoshis);
 
       await assertExpectedRejectedPeginEventIsEmitted(btcPeginTxHash, blockNumberBeforePegin, PEGIN_REJECTION_REASONS.INVALID_AMOUNT);
 


### PR DESCRIPTION
Adds 'should reject a basic pegin v1 with value exactly below minimum' test.

This test sends a pegin v1 with a value exactly below minimum (the minimum pegin value minus 1 satoshis), to assert that it should be rejected with rejection reason 5 (invalid amount).

Asserts that the sender funds are lost and that the sender's derived rsk address nor the pegin v1 rsk recipient address get any funds, but the federation balance is increased by the pegin amount while the Bridge doesn't mark that pegin tx as processed.