### PR TITLE
Put all pegin tests in their own test suite.

### DIFF
--- a/lib/tests/2wp.js
+++ b/lib/tests/2wp.js
@@ -46,632 +46,636 @@ const execute = (description, getRskHost) => {
 
     });
 
-    it('should do a basic legacy pegin with the exact minimum value', async () => {
-
-      // Arrange
-
-      const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
-      const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
-      const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
-      const peginValueInSatoshis = minimumPeginValueInSatoshis;
-
-      // Act
-
-      const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, satoshisToBtc(peginValueInSatoshis));
-      
-      // Assert
-
-      await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash);
-
-      await assertExpectedPeginBtcEventIsEmitted(btcPeginTxHash, senderRecipientInfo.rskRecipientRskAddressInfo.address, peginValueInSatoshis);
-
-      await assert2wpBalancesAfterSuccessfulPegin(initial2wpBalances, peginValueInSatoshis);
+    describe('Pegin test', () => {
+
+      it('should do a basic legacy pegin with the exact minimum value', async () => {
+
+        // Arrange
+
+        const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
+        const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
+        const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+        const peginValueInSatoshis = minimumPeginValueInSatoshis;
+
+        // Act
 
-      // The btc sender address balance is decreased by the pegin value and the btc fee
-      const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
-      expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
+        const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, satoshisToBtc(peginValueInSatoshis));
+        
+        // Assert
+
+        await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash);
+
+        await assertExpectedPeginBtcEventIsEmitted(btcPeginTxHash, senderRecipientInfo.rskRecipientRskAddressInfo.address, peginValueInSatoshis);
 
-      // The recipient rsk address balance is increased by the pegin value
-      const finalRskRecipientBalanceInWeisBN = await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address);
-      const expectedRskRecipientBalancesInWeisBN = new BN(satoshisToWeis(peginValueInSatoshis));
-      expect(finalRskRecipientBalanceInWeisBN.eq(expectedRskRecipientBalancesInWeisBN)).to.be.true;
+        await assert2wpBalancesAfterSuccessfulPegin(initial2wpBalances, peginValueInSatoshis);
 
-    });
+        // The btc sender address balance is decreased by the pegin value and the btc fee
+        const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+        expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
 
-    it('should do a basic legacy pegin with the value exactly above minimum', async () => {
+        // The recipient rsk address balance is increased by the pegin value
+        const finalRskRecipientBalanceInWeisBN = await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address);
+        const expectedRskRecipientBalancesInWeisBN = new BN(satoshisToWeis(peginValueInSatoshis));
+        expect(finalRskRecipientBalanceInWeisBN.eq(expectedRskRecipientBalancesInWeisBN)).to.be.true;
 
-      // Arrange
+      });
 
-      const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
-      const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
-      const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
-      // Value exactly above minimum
-      const peginValueInSatoshis = minimumPeginValueInSatoshis + 1;
+      it('should do a basic legacy pegin with the value exactly above minimum', async () => {
 
-      // Act
+        // Arrange
 
-      const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, satoshisToBtc(peginValueInSatoshis));
+        const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
+        const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
+        const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+        // Value exactly above minimum
+        const peginValueInSatoshis = minimumPeginValueInSatoshis + 1;
 
-      // Assert
+        // Act
 
-      await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash);
+        const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, satoshisToBtc(peginValueInSatoshis));
 
-      await assertExpectedPeginBtcEventIsEmitted(btcPeginTxHash, senderRecipientInfo.rskRecipientRskAddressInfo.address, peginValueInSatoshis);
+        // Assert
 
-      await assert2wpBalancesAfterSuccessfulPegin(initial2wpBalances, peginValueInSatoshis);
+        await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash);
 
-      // The sender address balance is decreased by the pegin value and the btc fee
-      const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
-      expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
+        await assertExpectedPeginBtcEventIsEmitted(btcPeginTxHash, senderRecipientInfo.rskRecipientRskAddressInfo.address, peginValueInSatoshis);
 
-      // The recipient rsk address balance is increased by the pegin value
-      const finalRskRecipientBalanceInWeisBN = await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address);
-      const expectedRskRecipientBalancesInWeisBN = new BN(satoshisToWeis(peginValueInSatoshis));
-      expect(finalRskRecipientBalanceInWeisBN.eq(expectedRskRecipientBalancesInWeisBN)).to.be.true;
+        await assert2wpBalancesAfterSuccessfulPegin(initial2wpBalances, peginValueInSatoshis);
 
-    });
+        // The sender address balance is decreased by the pegin value and the btc fee
+        const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+        expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
 
-    it('should do a basic pegin v1 with the exact minimum value', async () => {
+        // The recipient rsk address balance is increased by the pegin value
+        const finalRskRecipientBalanceInWeisBN = await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address);
+        const expectedRskRecipientBalancesInWeisBN = new BN(satoshisToWeis(peginValueInSatoshis));
+        expect(finalRskRecipientBalanceInWeisBN.eq(expectedRskRecipientBalancesInWeisBN)).to.be.true;
 
-      // Arrange
-  
-      const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
-      const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
-      const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
-      const peginValueInSatoshis = minimumPeginValueInSatoshis;
-      const peginV1RskRecipientAddress = await rskTxHelper.newAccountWithSeed('successfulPeginV1');
-  
-      // Act
-  
-      const peginV1Data = [Buffer.from(createPeginV1TxData(peginV1RskRecipientAddress), 'hex')];
-  
-      const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, Number(satoshisToBtc(peginValueInSatoshis)), peginV1Data);
-  
-      // Assert
-  
-      await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash);
-  
-      const expectedPeginProtocolVersion = '1';
-      await assertExpectedPeginBtcEventIsEmitted(btcPeginTxHash, peginV1RskRecipientAddress, peginValueInSatoshis, expectedPeginProtocolVersion);
-  
-      await assert2wpBalancesAfterSuccessfulPegin(initial2wpBalances, peginValueInSatoshis);
-  
-      // The sender address balance is decreased by the pegin value and the btc fee
-      const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
-      expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
-  
-      // The sender derived rsk address rsk address balance is unchanged
-      const finalSenderDerivedRskAddressBalanceInWeisBN = await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address);
-      expect(finalSenderDerivedRskAddressBalanceInWeisBN.eq(new BN('0'))).to.be.true;
-  
-      // The pegin v1 rsk recipient address has the funds
-      const finalRskRecipientBalanceInWeisBN = await rskTxHelper.getBalance(peginV1RskRecipientAddress);
-      const expectedFinalRskRecipientBalanceInWeisBN = new BN(satoshisToWeis(peginValueInSatoshis));
-      expect(finalRskRecipientBalanceInWeisBN.eq(expectedFinalRskRecipientBalanceInWeisBN)).to.be.true;
-  
-    });
+      });
 
-    it('should reject and not refund a legacy pegin with the value exactly below minimum', async () => {
+      it('should do a basic pegin v1 with the exact minimum value', async () => {
 
-      // Arrange
+        // Arrange
+    
+        const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
+        const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
+        const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+        const peginValueInSatoshis = minimumPeginValueInSatoshis;
+        const peginV1RskRecipientAddress = await rskTxHelper.newAccountWithSeed('successfulPeginV1');
+    
+        // Act
+    
+        const peginV1Data = [Buffer.from(createPeginV1TxData(peginV1RskRecipientAddress), 'hex')];
+    
+        const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, Number(satoshisToBtc(peginValueInSatoshis)), peginV1Data);
+    
+        // Assert
+    
+        await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash);
+    
+        const expectedPeginProtocolVersion = '1';
+        await assertExpectedPeginBtcEventIsEmitted(btcPeginTxHash, peginV1RskRecipientAddress, peginValueInSatoshis, expectedPeginProtocolVersion);
+    
+        await assert2wpBalancesAfterSuccessfulPegin(initial2wpBalances, peginValueInSatoshis);
+    
+        // The sender address balance is decreased by the pegin value and the btc fee
+        const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+        expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
+    
+        // The sender derived rsk address rsk address balance is unchanged
+        const finalSenderDerivedRskAddressBalanceInWeisBN = await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address);
+        expect(finalSenderDerivedRskAddressBalanceInWeisBN.eq(new BN('0'))).to.be.true;
+    
+        // The pegin v1 rsk recipient address has the funds
+        const finalRskRecipientBalanceInWeisBN = await rskTxHelper.getBalance(peginV1RskRecipientAddress);
+        const expectedFinalRskRecipientBalanceInWeisBN = new BN(satoshisToWeis(peginValueInSatoshis));
+        expect(finalRskRecipientBalanceInWeisBN.eq(expectedFinalRskRecipientBalanceInWeisBN)).to.be.true;
+    
+      });
 
-      const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
-      const initialFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
-      const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
-      const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
-      // The minimum pegin value minus 1 satoshis
-      const peginValueInSatoshis = minimumPeginValueInSatoshis - 1;
+      it('should reject and not refund a legacy pegin with the value exactly below minimum', async () => {
 
-      // Act
+        // Arrange
 
-      const blockNumberBeforePegin = await rskTxHelper.getBlockNumber();
+        const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
+        const initialFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
+        const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
+        const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+        // The minimum pegin value minus 1 satoshis
+        const peginValueInSatoshis = minimumPeginValueInSatoshis - 1;
 
-      const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, Number(satoshisToBtc(peginValueInSatoshis)));
-      // Funds of a pegin with value below minimum are lost. But calling triggerRelease here to ensure that nothing will be refunded.
-      await triggerRelease(rskTxHelpers, btcTxHelper);
+        // Act
 
-      // Assert
+        const blockNumberBeforePegin = await rskTxHelper.getBlockNumber();
 
-      // The btc pegin tx is not marked as processed by the bridge
-      await assertPeginTxHashNotProcessed(btcPeginTxHash);
+        const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, Number(satoshisToBtc(peginValueInSatoshis)));
+        // Funds of a pegin with value below minimum are lost. But calling triggerRelease here to ensure that nothing will be refunded.
+        await triggerRelease(rskTxHelpers, btcTxHelper);
 
-      await assert2wpBalancesPeginRejectedNoRefund(initial2wpBalances, peginValueInSatoshis);
+        // Assert
 
-      await assertExpectedRejectedPeginEventIsEmitted(btcPeginTxHash, blockNumberBeforePegin, PEGIN_REJECTION_REASONS.INVALID_AMOUNT);
-      await assertExpectedUnrefundablePeginEventIsEmitted(btcPeginTxHash, blockNumberBeforePegin, PEGIN_UNREFUNDABLE_REASONS.INVALID_AMOUNT);
+        // The btc pegin tx is not marked as processed by the bridge
+        await assertPeginTxHashNotProcessed(btcPeginTxHash);
 
-      // The federation balance is increased by the pegin value
-      const finalFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
-      expect(finalFederationAddressBalanceInSatoshis).to.be.equal(initialFederationAddressBalanceInSatoshis + peginValueInSatoshis);
+        await assert2wpBalancesPeginRejectedNoRefund(initial2wpBalances, peginValueInSatoshis);
 
-      // The sender address balance is decreased by the pegin value and the btc fee
-      const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
-      expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
+        await assertExpectedRejectedPeginEventIsEmitted(btcPeginTxHash, blockNumberBeforePegin, PEGIN_REJECTION_REASONS.INVALID_AMOUNT);
+        await assertExpectedUnrefundablePeginEventIsEmitted(btcPeginTxHash, blockNumberBeforePegin, PEGIN_UNREFUNDABLE_REASONS.INVALID_AMOUNT);
 
-      // The recipient rsk address balance is zero
-      const finalRskRecipientBalance = Number(await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address));
-      expect(finalRskRecipientBalance).to.be.equal(0);
+        // The federation balance is increased by the pegin value
+        const finalFederationAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, federationAddress);
+        expect(finalFederationAddressBalanceInSatoshis).to.be.equal(initialFederationAddressBalanceInSatoshis + peginValueInSatoshis);
 
-    });
+        // The sender address balance is decreased by the pegin value and the btc fee
+        const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+        expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
 
-    it('should reject and not refund a basic pegin v1 with value exactly below minimum', async () => {
+        // The recipient rsk address balance is zero
+        const finalRskRecipientBalance = Number(await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address));
+        expect(finalRskRecipientBalance).to.be.equal(0);
 
-      // Arrange
+      });
 
-      const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
-      const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
-      const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
-      // The minimum pegin value minus 1 satoshis
-      const peginValueInSatoshis = minimumPeginValueInSatoshis - 1;
-      
-      const peginV1RskRecipientAddress = await rskTxHelper.newAccountWithSeed('rejectedPeginV1');
+      it('should reject and not refund a basic pegin v1 with value exactly below minimum', async () => {
 
-      // Act
+        // Arrange
 
-      const peginV1Data = [Buffer.from(createPeginV1TxData(peginV1RskRecipientAddress), 'hex')];
+        const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
+        const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
+        const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+        // The minimum pegin value minus 1 satoshis
+        const peginValueInSatoshis = minimumPeginValueInSatoshis - 1;
+        
+        const peginV1RskRecipientAddress = await rskTxHelper.newAccountWithSeed('rejectedPeginV1');
 
-      const blockNumberBeforePegin = await rskTxHelper.getBlockNumber();
+        // Act
 
-      const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, satoshisToBtc(peginValueInSatoshis), peginV1Data);
-      // Funds of a pegin with value below minimum are lost. But calling triggerRelease here to ensure that nothing will be refunded.
-      await triggerRelease(rskTxHelpers, btcTxHelper);
+        const peginV1Data = [Buffer.from(createPeginV1TxData(peginV1RskRecipientAddress), 'hex')];
 
-      // Assert
+        const blockNumberBeforePegin = await rskTxHelper.getBlockNumber();
 
-      // The btc pegin tx is not marked as processed by the bridge
-      await assertPeginTxHashNotProcessed(btcPeginTxHash);
+        const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, satoshisToBtc(peginValueInSatoshis), peginV1Data);
+        // Funds of a pegin with value below minimum are lost. But calling triggerRelease here to ensure that nothing will be refunded.
+        await triggerRelease(rskTxHelpers, btcTxHelper);
 
-      await assert2wpBalancesPeginRejectedNoRefund(initial2wpBalances, peginValueInSatoshis);
+        // Assert
 
-      await assertExpectedRejectedPeginEventIsEmitted(btcPeginTxHash, blockNumberBeforePegin, PEGIN_REJECTION_REASONS.INVALID_AMOUNT);
-      await assertExpectedUnrefundablePeginEventIsEmitted(btcPeginTxHash, blockNumberBeforePegin, PEGIN_UNREFUNDABLE_REASONS.INVALID_AMOUNT);
+        // The btc pegin tx is not marked as processed by the bridge
+        await assertPeginTxHashNotProcessed(btcPeginTxHash);
 
-      // The sender address balance is decreased by the pegin value and the btc fee
-      const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
-      expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
+        await assert2wpBalancesPeginRejectedNoRefund(initial2wpBalances, peginValueInSatoshis);
 
-      // The sender derived rsk address rsk address balance is unchanged
-      const finalSenderDerivedRskAddressBalance = Number(await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address));
-      expect(finalSenderDerivedRskAddressBalance).to.be.equal(0);
+        await assertExpectedRejectedPeginEventIsEmitted(btcPeginTxHash, blockNumberBeforePegin, PEGIN_REJECTION_REASONS.INVALID_AMOUNT);
+        await assertExpectedUnrefundablePeginEventIsEmitted(btcPeginTxHash, blockNumberBeforePegin, PEGIN_UNREFUNDABLE_REASONS.INVALID_AMOUNT);
 
-      // The pegin v1 rsk recipient address is also zero
-      const finalRskRecipientBalance = Number(await rskTxHelper.getBalance(peginV1RskRecipientAddress));
-      expect(finalRskRecipientBalance).to.be.equal(0);
+        // The sender address balance is decreased by the pegin value and the btc fee
+        const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+        expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
 
-    });
+        // The sender derived rsk address rsk address balance is unchanged
+        const finalSenderDerivedRskAddressBalance = Number(await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address));
+        expect(finalSenderDerivedRskAddressBalance).to.be.equal(0);
 
-    it('should reject and refund a legacy pegin from a multisig account with the value exactly minimum', async () => {
+        // The pegin v1 rsk recipient address is also zero
+        const finalRskRecipientBalance = Number(await rskTxHelper.getBalance(peginV1RskRecipientAddress));
+        expect(finalRskRecipientBalance).to.be.equal(0);
 
-      // Arrange
+      });
 
-      const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
-      const multisigSenderAddressInfo = await btcTxHelper.generateMultisigAddress(3, 2, 'legacy');
-      const peginValueInSatoshis = minimumPeginValueInSatoshis;
-      await btcTxHelper.fundAddress(multisigSenderAddressInfo.address, Number(satoshisToBtc(peginValueInSatoshis + btcFeeInSatoshis)));
+      it('should reject and refund a legacy pegin from a multisig account with the value exactly minimum', async () => {
 
-      // Act
+        // Arrange
 
-      const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, multisigSenderAddressInfo, Number(satoshisToBtc(peginValueInSatoshis)));
+        const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
+        const multisigSenderAddressInfo = await btcTxHelper.generateMultisigAddress(3, 2, 'legacy');
+        const peginValueInSatoshis = minimumPeginValueInSatoshis;
+        await btcTxHelper.fundAddress(multisigSenderAddressInfo.address, Number(satoshisToBtc(peginValueInSatoshis + btcFeeInSatoshis)));
 
-      // Assert
+        // Act
 
-      await assertBtcPeginTxHashProcessed(btcPeginTxHash);
+        const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, multisigSenderAddressInfo, Number(satoshisToBtc(peginValueInSatoshis)));
 
-      // The rejected_pegin event is emitted with the expected values
-      const btcTxHashProcessedHeight = Number(await bridge.methods.getBtcTxHashProcessedHeight(btcPeginTxHash).call());
-      await assertExpectedRejectedPeginEventIsEmitted(btcPeginTxHash, btcTxHashProcessedHeight, PEGIN_REJECTION_REASONS.LEGACY_PEGIN_MULTISIG_SENDER);
-      await assertExpectedReleaseRequestedEventIsEmitted(btcTxHashProcessedHeight, peginValueInSatoshis);
+        // Assert
 
-      // Expecting the multisig btc sender balance to be zero after the pegin.
-      const senderAddressBalanceAfterPegin = await getBtcAddressBalanceInSatoshis(btcTxHelper, multisigSenderAddressInfo.address);
-      expect(Number(senderAddressBalanceAfterPegin)).to.be.equal(0);
+        await assertBtcPeginTxHashProcessed(btcPeginTxHash);
 
-      // We are expecting a refund pegout to go through. So, let's push it.
-      await triggerRelease(rskTxHelpers, btcTxHelper);
+        // The rejected_pegin event is emitted with the expected values
+        const btcTxHashProcessedHeight = Number(await bridge.methods.getBtcTxHashProcessedHeight(btcPeginTxHash).call());
+        await assertExpectedRejectedPeginEventIsEmitted(btcPeginTxHash, btcTxHashProcessedHeight, PEGIN_REJECTION_REASONS.LEGACY_PEGIN_MULTISIG_SENDER);
+        await assertExpectedReleaseRequestedEventIsEmitted(btcTxHashProcessedHeight, peginValueInSatoshis);
 
-      await assert2wpBalanceIsUnchanged(initial2wpBalances);
+        // Expecting the multisig btc sender balance to be zero after the pegin.
+        const senderAddressBalanceAfterPegin = await getBtcAddressBalanceInSatoshis(btcTxHelper, multisigSenderAddressInfo.address);
+        expect(Number(senderAddressBalanceAfterPegin)).to.be.equal(0);
 
-      // Finally, the multisig btc sender address should have received the funds back minus certain fee.
-      const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, multisigSenderAddressInfo.address);
-      expect(finalSenderAddressBalanceInSatoshis).to.be.above(peginValueInSatoshis - btcFeeInSatoshis).and.below(peginValueInSatoshis)
+        // We are expecting a refund pegout to go through. So, let's push it.
+        await triggerRelease(rskTxHelpers, btcTxHelper);
 
-    });
+        await assert2wpBalanceIsUnchanged(initial2wpBalances);
 
-    it('should reject and not refund a legacy pegin from a multisig account with the value exactly below minimum', async () => {
+        // Finally, the multisig btc sender address should have received the funds back minus certain fee.
+        const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, multisigSenderAddressInfo.address);
+        expect(finalSenderAddressBalanceInSatoshis).to.be.above(peginValueInSatoshis - btcFeeInSatoshis).and.below(peginValueInSatoshis)
 
-      // Arrange
+      });
 
-      const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
-      const multisigSenderAddressInfo = await btcTxHelper.generateMultisigAddress(3, 2, 'legacy');
-      const peginValueInSatoshis = minimumPeginValueInSatoshis - 1;
-      await btcTxHelper.fundAddress(multisigSenderAddressInfo.address, Number(satoshisToBtc(peginValueInSatoshis + btcFeeInSatoshis)));
+      it('should reject and not refund a legacy pegin from a multisig account with the value exactly below minimum', async () => {
 
-      // Act
+        // Arrange
 
-      const blockNumberBeforePegin = await rskTxHelper.getBlockNumber();
+        const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
+        const multisigSenderAddressInfo = await btcTxHelper.generateMultisigAddress(3, 2, 'legacy');
+        const peginValueInSatoshis = minimumPeginValueInSatoshis - 1;
+        await btcTxHelper.fundAddress(multisigSenderAddressInfo.address, Number(satoshisToBtc(peginValueInSatoshis + btcFeeInSatoshis)));
 
-      const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, multisigSenderAddressInfo, Number(satoshisToBtc(peginValueInSatoshis)));
+        // Act
 
-      // Assert
+        const blockNumberBeforePegin = await rskTxHelper.getBlockNumber();
 
-      await assertPeginTxHashNotProcessed(btcPeginTxHash);
+        const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, multisigSenderAddressInfo, Number(satoshisToBtc(peginValueInSatoshis)));
 
-      await assertExpectedRejectedPeginEventIsEmitted(btcPeginTxHash, blockNumberBeforePegin, PEGIN_REJECTION_REASONS.INVALID_AMOUNT);
-      await assertExpectedUnrefundablePeginEventIsEmitted(btcPeginTxHash, blockNumberBeforePegin, PEGIN_UNREFUNDABLE_REASONS.INVALID_AMOUNT);
+        // Assert
 
-      // Expecting the multisig btc sender balance to be zero after the pegin.
-      const senderAddressBalanceAfterPegin = await getBtcAddressBalanceInSatoshis(btcTxHelper, multisigSenderAddressInfo.address);
-      expect(Number(senderAddressBalanceAfterPegin)).to.be.equal(0);
+        await assertPeginTxHashNotProcessed(btcPeginTxHash);
 
-      // To ensure no refund is made, let's try to push any possible refund pegout.
-      await triggerRelease(rskTxHelpers, btcTxHelper);
-
-      await assert2wpBalancesPeginRejectedNoRefund(initial2wpBalances, peginValueInSatoshis);
-
-      // Finally, the multisig btc sender address should not have received the funds back.
-      const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, multisigSenderAddressInfo.address);
-      expect(finalSenderAddressBalanceInSatoshis).to.be.equal(senderAddressBalanceAfterPegin);
-
-    });
-
-    it('should do a pegin v1 from multisig with the exact minimum value', async () => {
-
-      // Arrange
-  
-      const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
-      const multisigSenderAddressInfo = await btcTxHelper.generateMultisigAddress(3, 2, 'legacy');
-      await btcTxHelper.fundAddress(multisigSenderAddressInfo.address, Number(satoshisToBtc(minimumPeginValueInSatoshis + btcFeeInSatoshis)));
-      const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, multisigSenderAddressInfo.address);
-      const peginValueInSatoshis = minimumPeginValueInSatoshis;
-      const peginV1RskRecipientAddress = await rskTxHelper.newAccountWithSeed('successfulPeginV1FromMultisig');
-  
-      // Act
-  
-      const peginV1Data = [Buffer.from(createPeginV1TxData(peginV1RskRecipientAddress), 'hex')];
-  
-      const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, multisigSenderAddressInfo, Number(satoshisToBtc(peginValueInSatoshis)), peginV1Data);
-  
-      // Assert
-
-      await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash);
-  
-      const expectedPeginProtocolVersion = '1';
-      await assertExpectedPeginBtcEventIsEmitted(btcPeginTxHash, peginV1RskRecipientAddress, peginValueInSatoshis, expectedPeginProtocolVersion);
-  
-      await assert2wpBalancesAfterSuccessfulPegin(initial2wpBalances, peginValueInSatoshis);
-  
-      // The sender address balance is decreased by the pegin value and the btc fee
-      const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, multisigSenderAddressInfo.address);
-      expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
-  
-      // The pegin v1 rsk recipient address has the funds
-      const finalRskRecipientBalanceInWeisBN = await rskTxHelper.getBalance(peginV1RskRecipientAddress);
-      const expectedFinalRskRecipientBalanceInWeisBN = new BN(satoshisToWeis(peginValueInSatoshis));
-      expect(finalRskRecipientBalanceInWeisBN.eq(expectedFinalRskRecipientBalanceInWeisBN)).to.be.true;
-  
-    });
-
-
-    it('should do a pegin v1 from bech32 sender with the exact minimum value', async () => {
-
-      // Arrange
-  
-      const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
-      const bech32SenderAddressInfo = await btcTxHelper.generateBtcAddress('bech32');
-      await btcTxHelper.fundAddress(bech32SenderAddressInfo.address, Number(satoshisToBtc(minimumPeginValueInSatoshis + btcFeeInSatoshis)));
-      const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, bech32SenderAddressInfo.address);
-      const peginValueInSatoshis = minimumPeginValueInSatoshis;
-      const peginV1RskRecipientAddress = await rskTxHelper.newAccountWithSeed('successfulPeginV1FromBech32');
-  
-      // Act
-  
-      const peginV1Data = [Buffer.from(createPeginV1TxData(peginV1RskRecipientAddress), 'hex')];
-  
-      const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, bech32SenderAddressInfo, Number(satoshisToBtc(peginValueInSatoshis)), peginV1Data);
-  
-      // Assert
-  
-      await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash);
-  
-      const expectedPeginProtocolVersion = '1';
-      await assertExpectedPeginBtcEventIsEmitted(btcPeginTxHash, peginV1RskRecipientAddress, peginValueInSatoshis, expectedPeginProtocolVersion);
-  
-      await assert2wpBalancesAfterSuccessfulPegin(initial2wpBalances, peginValueInSatoshis);
-  
-      // The sender address balance is decreased by the pegin value and the btc fee
-      const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, bech32SenderAddressInfo.address);
-      expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
-  
-      // The pegin v1 rsk recipient address has the funds
-      const finalRskRecipientBalanceInWeisBN = await rskTxHelper.getBalance(peginV1RskRecipientAddress);
-      const expectedFinalRskRecipientBalanceInWeisBN = new BN(satoshisToWeis(peginValueInSatoshis));
-      expect(finalRskRecipientBalanceInWeisBN.eq(expectedFinalRskRecipientBalanceInWeisBN)).to.be.true;
-  
-    });
+        await assertExpectedRejectedPeginEventIsEmitted(btcPeginTxHash, blockNumberBeforePegin, PEGIN_REJECTION_REASONS.INVALID_AMOUNT);
+        await assertExpectedUnrefundablePeginEventIsEmitted(btcPeginTxHash, blockNumberBeforePegin, PEGIN_UNREFUNDABLE_REASONS.INVALID_AMOUNT);
 
-    it('should do a basic pegin v1 with btc refund address and the exact minimum value', async () => {
+        // Expecting the multisig btc sender balance to be zero after the pegin.
+        const senderAddressBalanceAfterPegin = await getBtcAddressBalanceInSatoshis(btcTxHelper, multisigSenderAddressInfo.address);
+        expect(Number(senderAddressBalanceAfterPegin)).to.be.equal(0);
+
+        // To ensure no refund is made, let's try to push any possible refund pegout.
+        await triggerRelease(rskTxHelpers, btcTxHelper);
+
+        await assert2wpBalancesPeginRejectedNoRefund(initial2wpBalances, peginValueInSatoshis);
+
+        // Finally, the multisig btc sender address should not have received the funds back.
+        const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, multisigSenderAddressInfo.address);
+        expect(finalSenderAddressBalanceInSatoshis).to.be.equal(senderAddressBalanceAfterPegin);
+
+      });
+
+      it('should do a pegin v1 from multisig with the exact minimum value', async () => {
+
+        // Arrange
+    
+        const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
+        const multisigSenderAddressInfo = await btcTxHelper.generateMultisigAddress(3, 2, 'legacy');
+        await btcTxHelper.fundAddress(multisigSenderAddressInfo.address, Number(satoshisToBtc(minimumPeginValueInSatoshis + btcFeeInSatoshis)));
+        const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, multisigSenderAddressInfo.address);
+        const peginValueInSatoshis = minimumPeginValueInSatoshis;
+        const peginV1RskRecipientAddress = await rskTxHelper.newAccountWithSeed('successfulPeginV1FromMultisig');
+    
+        // Act
+    
+        const peginV1Data = [Buffer.from(createPeginV1TxData(peginV1RskRecipientAddress), 'hex')];
+    
+        const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, multisigSenderAddressInfo, Number(satoshisToBtc(peginValueInSatoshis)), peginV1Data);
+    
+        // Assert
+
+        await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash);
+    
+        const expectedPeginProtocolVersion = '1';
+        await assertExpectedPeginBtcEventIsEmitted(btcPeginTxHash, peginV1RskRecipientAddress, peginValueInSatoshis, expectedPeginProtocolVersion);
+    
+        await assert2wpBalancesAfterSuccessfulPegin(initial2wpBalances, peginValueInSatoshis);
+    
+        // The sender address balance is decreased by the pegin value and the btc fee
+        const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, multisigSenderAddressInfo.address);
+        expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
+    
+        // The pegin v1 rsk recipient address has the funds
+        const finalRskRecipientBalanceInWeisBN = await rskTxHelper.getBalance(peginV1RskRecipientAddress);
+        const expectedFinalRskRecipientBalanceInWeisBN = new BN(satoshisToWeis(peginValueInSatoshis));
+        expect(finalRskRecipientBalanceInWeisBN.eq(expectedFinalRskRecipientBalanceInWeisBN)).to.be.true;
+    
+      });
+
+
+      it('should do a pegin v1 from bech32 sender with the exact minimum value', async () => {
+
+        // Arrange
+    
+        const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
+        const bech32SenderAddressInfo = await btcTxHelper.generateBtcAddress('bech32');
+        await btcTxHelper.fundAddress(bech32SenderAddressInfo.address, Number(satoshisToBtc(minimumPeginValueInSatoshis + btcFeeInSatoshis)));
+        const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, bech32SenderAddressInfo.address);
+        const peginValueInSatoshis = minimumPeginValueInSatoshis;
+        const peginV1RskRecipientAddress = await rskTxHelper.newAccountWithSeed('successfulPeginV1FromBech32');
+    
+        // Act
+    
+        const peginV1Data = [Buffer.from(createPeginV1TxData(peginV1RskRecipientAddress), 'hex')];
+    
+        const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, bech32SenderAddressInfo, Number(satoshisToBtc(peginValueInSatoshis)), peginV1Data);
+    
+        // Assert
+    
+        await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash);
+    
+        const expectedPeginProtocolVersion = '1';
+        await assertExpectedPeginBtcEventIsEmitted(btcPeginTxHash, peginV1RskRecipientAddress, peginValueInSatoshis, expectedPeginProtocolVersion);
+    
+        await assert2wpBalancesAfterSuccessfulPegin(initial2wpBalances, peginValueInSatoshis);
+    
+        // The sender address balance is decreased by the pegin value and the btc fee
+        const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, bech32SenderAddressInfo.address);
+        expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
+    
+        // The pegin v1 rsk recipient address has the funds
+        const finalRskRecipientBalanceInWeisBN = await rskTxHelper.getBalance(peginV1RskRecipientAddress);
+        const expectedFinalRskRecipientBalanceInWeisBN = new BN(satoshisToWeis(peginValueInSatoshis));
+        expect(finalRskRecipientBalanceInWeisBN.eq(expectedFinalRskRecipientBalanceInWeisBN)).to.be.true;
+    
+      });
 
-      // Arrange
-  
-      const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
-      const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
-      const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
-      const peginValueInSatoshis = minimumPeginValueInSatoshis;
-      const peginV1RskRecipientAddress = await rskTxHelper.newAccountWithSeed('successfulPeginV1WithBtcRefundAddress');
-  
-      // Act
-  
-      const peginV1Data = [Buffer.from(createPeginV1TxData(peginV1RskRecipientAddress, senderRecipientInfo.btcSenderAddressInfo.address), 'hex')];
-  
-      const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, Number(satoshisToBtc(peginValueInSatoshis)), peginV1Data);
-  
-      // Assert
-  
-      await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash);
-  
-      const expectedPeginProtocolVersion = '1';
-      await assertExpectedPeginBtcEventIsEmitted(btcPeginTxHash, peginV1RskRecipientAddress, peginValueInSatoshis, expectedPeginProtocolVersion);
-  
-      await assert2wpBalancesAfterSuccessfulPegin(initial2wpBalances, peginValueInSatoshis);
-  
-      // The sender address balance is decreased by the pegin value and the btc fee
-      const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
-      expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
-  
-      // The sender derived rsk address rsk address balance is unchanged
-      const finalSenderDerivedRskAddressBalanceInWeisBN = await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address);
-      expect(finalSenderDerivedRskAddressBalanceInWeisBN.eq(new BN('0'))).to.be.true;
-  
-      // The pegin v1 rsk recipient address has the funds
-      const finalRskRecipientBalanceInWeisBN = await rskTxHelper.getBalance(peginV1RskRecipientAddress);
-      const expectedFinalRskRecipientBalanceInWeisBN = new BN(satoshisToWeis(peginValueInSatoshis));
-      expect(finalRskRecipientBalanceInWeisBN.eq(expectedFinalRskRecipientBalanceInWeisBN)).to.be.true;
-  
-    });
+      it('should do a basic pegin v1 with btc refund address and the exact minimum value', async () => {
 
-    it('should reject and not refund a legacy pegin from a bech32 sender with the value exactly minimum', async () => {
+        // Arrange
+    
+        const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
+        const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
+        const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+        const peginValueInSatoshis = minimumPeginValueInSatoshis;
+        const peginV1RskRecipientAddress = await rskTxHelper.newAccountWithSeed('successfulPeginV1WithBtcRefundAddress');
+    
+        // Act
+    
+        const peginV1Data = [Buffer.from(createPeginV1TxData(peginV1RskRecipientAddress, senderRecipientInfo.btcSenderAddressInfo.address), 'hex')];
+    
+        const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, Number(satoshisToBtc(peginValueInSatoshis)), peginV1Data);
+    
+        // Assert
+    
+        await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash);
+    
+        const expectedPeginProtocolVersion = '1';
+        await assertExpectedPeginBtcEventIsEmitted(btcPeginTxHash, peginV1RskRecipientAddress, peginValueInSatoshis, expectedPeginProtocolVersion);
+    
+        await assert2wpBalancesAfterSuccessfulPegin(initial2wpBalances, peginValueInSatoshis);
+    
+        // The sender address balance is decreased by the pegin value and the btc fee
+        const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+        expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
+    
+        // The sender derived rsk address rsk address balance is unchanged
+        const finalSenderDerivedRskAddressBalanceInWeisBN = await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address);
+        expect(finalSenderDerivedRskAddressBalanceInWeisBN.eq(new BN('0'))).to.be.true;
+    
+        // The pegin v1 rsk recipient address has the funds
+        const finalRskRecipientBalanceInWeisBN = await rskTxHelper.getBalance(peginV1RskRecipientAddress);
+        const expectedFinalRskRecipientBalanceInWeisBN = new BN(satoshisToWeis(peginValueInSatoshis));
+        expect(finalRskRecipientBalanceInWeisBN.eq(expectedFinalRskRecipientBalanceInWeisBN)).to.be.true;
+    
+      });
 
-      // Arrange
+      it('should reject and not refund a legacy pegin from a bech32 sender with the value exactly minimum', async () => {
+
+        // Arrange
 
-      const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
-      const bech32SenderAddressInfo = await btcTxHelper.generateBtcAddress('bech32');
-      const peginValueInSatoshis = minimumPeginValueInSatoshis;
-      await btcTxHelper.fundAddress(bech32SenderAddressInfo.address, Number(satoshisToBtc(peginValueInSatoshis + btcFeeInSatoshis)));
+        const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
+        const bech32SenderAddressInfo = await btcTxHelper.generateBtcAddress('bech32');
+        const peginValueInSatoshis = minimumPeginValueInSatoshis;
+        await btcTxHelper.fundAddress(bech32SenderAddressInfo.address, Number(satoshisToBtc(peginValueInSatoshis + btcFeeInSatoshis)));
 
-      // Act
+        // Act
 
-      const blockNumberBeforePegin = await rskTxHelper.getBlockNumber();
+        const blockNumberBeforePegin = await rskTxHelper.getBlockNumber();
 
-      const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, bech32SenderAddressInfo, Number(satoshisToBtc(peginValueInSatoshis)));
+        const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, bech32SenderAddressInfo, Number(satoshisToBtc(peginValueInSatoshis)));
 
-      // Assert
+        // Assert
 
-      // To ensure no refund is made, let's try to push any possible refund pegout.
-      await triggerRelease(rskTxHelpers, btcTxHelper);
+        // To ensure no refund is made, let's try to push any possible refund pegout.
+        await triggerRelease(rskTxHelpers, btcTxHelper);
 
-      await assertPeginTxHashNotProcessed(btcPeginTxHash);
+        await assertPeginTxHashNotProcessed(btcPeginTxHash);
 
-      // Two events are emitted in this scenario: rejected_pegin and unrefundable_pegin.
-      await assertExpectedRejectedPeginEventIsEmitted(btcPeginTxHash, blockNumberBeforePegin, PEGIN_REJECTION_REASONS.LEGACY_PEGIN_UNDETERMINED_SENDER);
-      await assertExpectedUnrefundablePeginEventIsEmitted(btcPeginTxHash, blockNumberBeforePegin, PEGIN_UNREFUNDABLE_REASONS.LEGACY_PEGIN_UNDETERMINED_SENDER);
+        // Two events are emitted in this scenario: rejected_pegin and unrefundable_pegin.
+        await assertExpectedRejectedPeginEventIsEmitted(btcPeginTxHash, blockNumberBeforePegin, PEGIN_REJECTION_REASONS.LEGACY_PEGIN_UNDETERMINED_SENDER);
+        await assertExpectedUnrefundablePeginEventIsEmitted(btcPeginTxHash, blockNumberBeforePegin, PEGIN_UNREFUNDABLE_REASONS.LEGACY_PEGIN_UNDETERMINED_SENDER);
 
-      // Expecting the multisig btc sender balance to be zero after the pegin.
-      const senderAddressBalanceAfterPegin = await getBtcAddressBalanceInSatoshis(btcTxHelper, bech32SenderAddressInfo.address);
-      expect(Number(senderAddressBalanceAfterPegin)).to.be.equal(0);
+        // Expecting the multisig btc sender balance to be zero after the pegin.
+        const senderAddressBalanceAfterPegin = await getBtcAddressBalanceInSatoshis(btcTxHelper, bech32SenderAddressInfo.address);
+        expect(Number(senderAddressBalanceAfterPegin)).to.be.equal(0);
 
-      // To ensure no refund is made, let's try to push any possible refund pegout.
-      await triggerRelease(rskTxHelpers, btcTxHelper);
+        // To ensure no refund is made, let's try to push any possible refund pegout.
+        await triggerRelease(rskTxHelpers, btcTxHelper);
 
-      await assert2wpBalancesPeginRejectedNoRefund(initial2wpBalances, peginValueInSatoshis);
+        await assert2wpBalancesPeginRejectedNoRefund(initial2wpBalances, peginValueInSatoshis);
 
-      // Finally, the multisig btc sender address should not have received the funds back.
-      const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, bech32SenderAddressInfo.address);
-      expect(finalSenderAddressBalanceInSatoshis).to.be.equal(senderAddressBalanceAfterPegin);
+        // Finally, the multisig btc sender address should not have received the funds back.
+        const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, bech32SenderAddressInfo.address);
+        expect(finalSenderAddressBalanceInSatoshis).to.be.equal(senderAddressBalanceAfterPegin);
 
-    });
+      });
 
-    it('should reject and refund pegin with multiple OP_RETURN outputs for RSK with value exactly minimum', async () => {
+      it('should reject and refund pegin with multiple OP_RETURN outputs for RSK with value exactly minimum', async () => {
 
-      // Arrange
+        // Arrange
 
-      const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
-      const peginValueInSatoshis = minimumPeginValueInSatoshis;
-      const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper, 'p2sh-segwit', Number(satoshisToBtc(peginValueInSatoshis + btcFeeInSatoshis)));
-      const peginV1RskRecipientAddress = await rskTxHelper.newAccountWithSeed('rejectedPeginWithMultipleOpReturnOutputs');
+        const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
+        const peginValueInSatoshis = minimumPeginValueInSatoshis;
+        const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper, 'p2sh-segwit', Number(satoshisToBtc(peginValueInSatoshis + btcFeeInSatoshis)));
+        const peginV1RskRecipientAddress = await rskTxHelper.newAccountWithSeed('rejectedPeginWithMultipleOpReturnOutputs');
 
-      const data = [];
-      data.push(Buffer.from(createPeginV1TxData(senderRecipientInfo.rskRecipientRskAddressInfo.address), 'hex'));
-      data.push(Buffer.from(createPeginV1TxData(peginV1RskRecipientAddress), 'hex'));
+        const data = [];
+        data.push(Buffer.from(createPeginV1TxData(senderRecipientInfo.rskRecipientRskAddressInfo.address), 'hex'));
+        data.push(Buffer.from(createPeginV1TxData(peginV1RskRecipientAddress), 'hex'));
 
-      // Act
+        // Act
 
-      const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, satoshisToBtc(peginValueInSatoshis), data);
+        const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, satoshisToBtc(peginValueInSatoshis), data);
 
-      // Assert
+        // Assert
 
-      // Expecting the btc sender balance to be zero right after the pegin.
-      const senderAddressBalanceAfterPegin = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
-      expect(Number(senderAddressBalanceAfterPegin)).to.be.equal(0);
-      
-      // We are expecting a refund pegout to go through. So, let's push it.
-      await triggerRelease(rskTxHelpers, btcTxHelper);
-      
-      await assertBtcPeginTxHashProcessed(btcPeginTxHash);
+        // Expecting the btc sender balance to be zero right after the pegin.
+        const senderAddressBalanceAfterPegin = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+        expect(Number(senderAddressBalanceAfterPegin)).to.be.equal(0);
+        
+        // We are expecting a refund pegout to go through. So, let's push it.
+        await triggerRelease(rskTxHelpers, btcTxHelper);
+        
+        await assertBtcPeginTxHashProcessed(btcPeginTxHash);
 
-      // The rejected_pegin and released_requested events are emitted with the expected values
-      const btcTxHashProcessedHeight = Number(await bridge.methods.getBtcTxHashProcessedHeight(btcPeginTxHash).call());
-      await assertExpectedRejectedPeginEventIsEmitted(btcPeginTxHash, btcTxHashProcessedHeight, PEGIN_REJECTION_REASONS.PEGIN_V1_INVALID_PAYLOAD_REASON);
-      await assertExpectedReleaseRequestedEventIsEmitted(btcTxHashProcessedHeight, peginValueInSatoshis);
+        // The rejected_pegin and released_requested events are emitted with the expected values
+        const btcTxHashProcessedHeight = Number(await bridge.methods.getBtcTxHashProcessedHeight(btcPeginTxHash).call());
+        await assertExpectedRejectedPeginEventIsEmitted(btcPeginTxHash, btcTxHashProcessedHeight, PEGIN_REJECTION_REASONS.PEGIN_V1_INVALID_PAYLOAD_REASON);
+        await assertExpectedReleaseRequestedEventIsEmitted(btcTxHashProcessedHeight, peginValueInSatoshis);
 
-      await assert2wpBalanceIsUnchanged(initial2wpBalances);
+        await assert2wpBalanceIsUnchanged(initial2wpBalances);
 
-      // Finally, the btc sender address should have received the funds back minus certain fee.
-      const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
-      expect(finalSenderAddressBalanceInSatoshis).to.be.above(peginValueInSatoshis - btcFeeInSatoshis).and.below(peginValueInSatoshis)
-      
-      // Check the same UTXOs used for the peg-in tx were used for the reject tx
-      await assertRefundUtxosSameAsPeginUtxos(rskTxHelper, btcTxHelper, btcPeginTxHash, senderRecipientInfo.btcSenderAddressInfo.address);
+        // Finally, the btc sender address should have received the funds back minus certain fee.
+        const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+        expect(finalSenderAddressBalanceInSatoshis).to.be.above(peginValueInSatoshis - btcFeeInSatoshis).and.below(peginValueInSatoshis)
+        
+        // Check the same UTXOs used for the peg-in tx were used for the reject tx
+        await assertRefundUtxosSameAsPeginUtxos(rskTxHelper, btcTxHelper, btcPeginTxHash, senderRecipientInfo.btcSenderAddressInfo.address);
 
-    });
+      });
 
-    it('should do a pegin v1 with multiple OP_RETURN outputs but only one for RSK and the exact minimum value', async () => {
+      it('should do a pegin v1 with multiple OP_RETURN outputs but only one for RSK and the exact minimum value', async () => {
 
-      // Arrange
+        // Arrange
 
-      const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
-      const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
-      const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
-      const peginValueInSatoshis = minimumPeginValueInSatoshis;
-      const peginV1RskRecipientAddress = await rskTxHelper.newAccountWithSeed('successfulPeginV1Multiple_OP_RETURN');
+        const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
+        const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper);
+        const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+        const peginValueInSatoshis = minimumPeginValueInSatoshis;
+        const peginV1RskRecipientAddress = await rskTxHelper.newAccountWithSeed('successfulPeginV1Multiple_OP_RETURN');
 
-      // Act
+        // Act
 
-      const peginV1Data = [];
-      peginV1Data.push(Buffer.from('some random data', 'hex'));
-      peginV1Data.push(Buffer.from(createPeginV1TxData(peginV1RskRecipientAddress), 'hex'));
-      peginV1Data.push(Buffer.from('some more random data', 'hex'));
+        const peginV1Data = [];
+        peginV1Data.push(Buffer.from('some random data', 'hex'));
+        peginV1Data.push(Buffer.from(createPeginV1TxData(peginV1RskRecipientAddress), 'hex'));
+        peginV1Data.push(Buffer.from('some more random data', 'hex'));
 
-      const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, Number(satoshisToBtc(peginValueInSatoshis)), peginV1Data);
+        const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, Number(satoshisToBtc(peginValueInSatoshis)), peginV1Data);
 
-      // Assert
+        // Assert
 
-      await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash);
+        await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash);
 
-      const expectedPeginProtocolVersion = '1';
-      await assertExpectedPeginBtcEventIsEmitted(btcPeginTxHash, peginV1RskRecipientAddress, peginValueInSatoshis, expectedPeginProtocolVersion);
+        const expectedPeginProtocolVersion = '1';
+        await assertExpectedPeginBtcEventIsEmitted(btcPeginTxHash, peginV1RskRecipientAddress, peginValueInSatoshis, expectedPeginProtocolVersion);
 
-      await assert2wpBalancesAfterSuccessfulPegin(initial2wpBalances, peginValueInSatoshis);
+        await assert2wpBalancesAfterSuccessfulPegin(initial2wpBalances, peginValueInSatoshis);
 
-      // The sender address balance is decreased by the pegin value and the btc fee
-      const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
-      expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
+        // The sender address balance is decreased by the pegin value and the btc fee
+        const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+        expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
 
-      // The sender derived rsk address rsk address balance is unchanged
-      const finalSenderDerivedRskAddressBalanceInWeisBN = await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address);
-      expect(finalSenderDerivedRskAddressBalanceInWeisBN.eq(new BN('0'))).to.be.true;
+        // The sender derived rsk address rsk address balance is unchanged
+        const finalSenderDerivedRskAddressBalanceInWeisBN = await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address);
+        expect(finalSenderDerivedRskAddressBalanceInWeisBN.eq(new BN('0'))).to.be.true;
 
-      // The pegin v1 rsk recipient address has the funds
-      const finalRskRecipientBalanceInWeisBN = await rskTxHelper.getBalance(peginV1RskRecipientAddress);
-      const expectedFinalRskRecipientBalanceInWeisBN = new BN(satoshisToWeis(peginValueInSatoshis));
-      expect(finalRskRecipientBalanceInWeisBN.eq(expectedFinalRskRecipientBalanceInWeisBN)).to.be.true;
+        // The pegin v1 rsk recipient address has the funds
+        const finalRskRecipientBalanceInWeisBN = await rskTxHelper.getBalance(peginV1RskRecipientAddress);
+        const expectedFinalRskRecipientBalanceInWeisBN = new BN(satoshisToWeis(peginValueInSatoshis));
+        expect(finalRskRecipientBalanceInWeisBN.eq(expectedFinalRskRecipientBalanceInWeisBN)).to.be.true;
 
-    });
+      });
 
-    it('should reject and refund pegin with OP_RETURN output to RSK with invalid payload with value exactly minimum', async () => {
+      it('should reject and refund pegin with OP_RETURN output to RSK with invalid payload with value exactly minimum', async () => {
 
-      // Arrange
+        // Arrange
 
-      const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
-      const peginValueInSatoshis = minimumPeginValueInSatoshis;
-      const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper, 'p2sh-segwit', Number(satoshisToBtc(peginValueInSatoshis + btcFeeInSatoshis)));
-      
-      const peginV1InvalidPayload = `${PEGIN_V1_RSKT_PREFIX_HEX}randomdata`;
-      const peginV1Data = [Buffer.from(peginV1InvalidPayload, 'hex')];
+        const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
+        const peginValueInSatoshis = minimumPeginValueInSatoshis;
+        const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper, 'p2sh-segwit', Number(satoshisToBtc(peginValueInSatoshis + btcFeeInSatoshis)));
+        
+        const peginV1InvalidPayload = `${PEGIN_V1_RSKT_PREFIX_HEX}randomdata`;
+        const peginV1Data = [Buffer.from(peginV1InvalidPayload, 'hex')];
 
-      // Act
+        // Act
 
-      const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, satoshisToBtc(peginValueInSatoshis), peginV1Data);
+        const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, satoshisToBtc(peginValueInSatoshis), peginV1Data);
 
-      // Assert
+        // Assert
 
-      // Expecting the btc sender balance to be zero right after the pegin.
-      const senderAddressBalanceAfterPegin = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
-      expect(Number(senderAddressBalanceAfterPegin)).to.be.equal(0);
-      
-      // We are expecting a refund pegout to go through. So, let's push it.
-      await triggerRelease(rskTxHelpers, btcTxHelper);
-      
-      await assertBtcPeginTxHashProcessed(btcPeginTxHash);
+        // Expecting the btc sender balance to be zero right after the pegin.
+        const senderAddressBalanceAfterPegin = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+        expect(Number(senderAddressBalanceAfterPegin)).to.be.equal(0);
+        
+        // We are expecting a refund pegout to go through. So, let's push it.
+        await triggerRelease(rskTxHelpers, btcTxHelper);
+        
+        await assertBtcPeginTxHashProcessed(btcPeginTxHash);
 
-      // The rejected_pegin and released_requested events are emitted with the expected values
-      const btcTxHashProcessedHeight = Number(await bridge.methods.getBtcTxHashProcessedHeight(btcPeginTxHash).call());
-      await assertExpectedRejectedPeginEventIsEmitted(btcPeginTxHash, btcTxHashProcessedHeight, PEGIN_REJECTION_REASONS.PEGIN_V1_INVALID_PAYLOAD_REASON);
-      await assertExpectedReleaseRequestedEventIsEmitted(btcTxHashProcessedHeight, peginValueInSatoshis);
+        // The rejected_pegin and released_requested events are emitted with the expected values
+        const btcTxHashProcessedHeight = Number(await bridge.methods.getBtcTxHashProcessedHeight(btcPeginTxHash).call());
+        await assertExpectedRejectedPeginEventIsEmitted(btcPeginTxHash, btcTxHashProcessedHeight, PEGIN_REJECTION_REASONS.PEGIN_V1_INVALID_PAYLOAD_REASON);
+        await assertExpectedReleaseRequestedEventIsEmitted(btcTxHashProcessedHeight, peginValueInSatoshis);
 
-      await assert2wpBalanceIsUnchanged(initial2wpBalances);
+        await assert2wpBalanceIsUnchanged(initial2wpBalances);
 
-      // Finally, the btc sender address should have received the funds back minus certain fee.
-      const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
-      expect(finalSenderAddressBalanceInSatoshis).to.be.above(peginValueInSatoshis - btcFeeInSatoshis).and.below(peginValueInSatoshis)
-      
-      // Check the same UTXOs used for the peg-in tx were used for the reject tx
-      await assertRefundUtxosSameAsPeginUtxos(rskTxHelper, btcTxHelper, btcPeginTxHash, senderRecipientInfo.btcSenderAddressInfo.address);
+        // Finally, the btc sender address should have received the funds back minus certain fee.
+        const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+        expect(finalSenderAddressBalanceInSatoshis).to.be.above(peginValueInSatoshis - btcFeeInSatoshis).and.below(peginValueInSatoshis)
+        
+        // Check the same UTXOs used for the peg-in tx were used for the reject tx
+        await assertRefundUtxosSameAsPeginUtxos(rskTxHelper, btcTxHelper, btcPeginTxHash, senderRecipientInfo.btcSenderAddressInfo.address);
 
-    });
+      });
 
-    it('should reject and refund pegin with invalid pegin v1 version with value exactly minimum', async () => {
+      it('should reject and refund pegin with invalid pegin v1 version with value exactly minimum', async () => {
 
-      // Arrange
+        // Arrange
 
-      const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
-      const peginValueInSatoshis = minimumPeginValueInSatoshis;
-      const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper, 'p2sh-segwit', Number(satoshisToBtc(peginValueInSatoshis + btcFeeInSatoshis)));
-      const peginV1RskRecipientAddress = await rskTxHelper.newAccountWithSeed('successfulPeginV1InvalidVersion');
+        const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
+        const peginValueInSatoshis = minimumPeginValueInSatoshis;
+        const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper, 'p2sh-segwit', Number(satoshisToBtc(peginValueInSatoshis + btcFeeInSatoshis)));
+        const peginV1RskRecipientAddress = await rskTxHelper.newAccountWithSeed('successfulPeginV1InvalidVersion');
 
-      const invalidPeginV1Version = '999';
-      const peginV1InvalidPayload = `${PEGIN_V1_RSKT_PREFIX_HEX}${invalidPeginV1Version}${removePrefix0x(peginV1RskRecipientAddress)}`;
-      const peginV1Data = [Buffer.from(peginV1InvalidPayload, 'hex')];
+        const invalidPeginV1Version = '999';
+        const peginV1InvalidPayload = `${PEGIN_V1_RSKT_PREFIX_HEX}${invalidPeginV1Version}${removePrefix0x(peginV1RskRecipientAddress)}`;
+        const peginV1Data = [Buffer.from(peginV1InvalidPayload, 'hex')];
 
-      // Act
+        // Act
 
-      const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, satoshisToBtc(peginValueInSatoshis), peginV1Data);
+        const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, satoshisToBtc(peginValueInSatoshis), peginV1Data);
 
-      // Assert
+        // Assert
 
-      // Expecting the btc sender balance to be zero right after the pegin.
-      const senderAddressBalanceAfterPegin = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
-      expect(Number(senderAddressBalanceAfterPegin)).to.be.equal(0);
-      
-      // We are expecting a refund pegout to go through. So, let's push it.
-      await triggerRelease(rskTxHelpers, btcTxHelper);
-      
-      await assertBtcPeginTxHashProcessed(btcPeginTxHash);
+        // Expecting the btc sender balance to be zero right after the pegin.
+        const senderAddressBalanceAfterPegin = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+        expect(Number(senderAddressBalanceAfterPegin)).to.be.equal(0);
+        
+        // We are expecting a refund pegout to go through. So, let's push it.
+        await triggerRelease(rskTxHelpers, btcTxHelper);
+        
+        await assertBtcPeginTxHashProcessed(btcPeginTxHash);
 
-      // The rejected_pegin and released_requested events are emitted with the expected values
-      const btcTxHashProcessedHeight = Number(await bridge.methods.getBtcTxHashProcessedHeight(btcPeginTxHash).call());
-      await assertExpectedRejectedPeginEventIsEmitted(btcPeginTxHash, btcTxHashProcessedHeight, PEGIN_REJECTION_REASONS.PEGIN_V1_INVALID_PAYLOAD_REASON);
-      await assertExpectedReleaseRequestedEventIsEmitted(btcTxHashProcessedHeight, peginValueInSatoshis);
+        // The rejected_pegin and released_requested events are emitted with the expected values
+        const btcTxHashProcessedHeight = Number(await bridge.methods.getBtcTxHashProcessedHeight(btcPeginTxHash).call());
+        await assertExpectedRejectedPeginEventIsEmitted(btcPeginTxHash, btcTxHashProcessedHeight, PEGIN_REJECTION_REASONS.PEGIN_V1_INVALID_PAYLOAD_REASON);
+        await assertExpectedReleaseRequestedEventIsEmitted(btcTxHashProcessedHeight, peginValueInSatoshis);
 
-      await assert2wpBalanceIsUnchanged(initial2wpBalances);
+        await assert2wpBalanceIsUnchanged(initial2wpBalances);
 
-      // Finally, the btc sender address should have received the funds back minus certain fee.
-      const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
-      expect(finalSenderAddressBalanceInSatoshis).to.be.above(peginValueInSatoshis - btcFeeInSatoshis).and.below(peginValueInSatoshis)
-      
-      // Check the same UTXOs used for the peg-in tx were used for the reject tx
-      await assertRefundUtxosSameAsPeginUtxos(rskTxHelper, btcTxHelper, btcPeginTxHash, senderRecipientInfo.btcSenderAddressInfo.address);
+        // Finally, the btc sender address should have received the funds back minus certain fee.
+        const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+        expect(finalSenderAddressBalanceInSatoshis).to.be.above(peginValueInSatoshis - btcFeeInSatoshis).and.below(peginValueInSatoshis)
+        
+        // Check the same UTXOs used for the peg-in tx were used for the reject tx
+        await assertRefundUtxosSameAsPeginUtxos(rskTxHelper, btcTxHelper, btcPeginTxHash, senderRecipientInfo.btcSenderAddressInfo.address);
 
-    });
+      });
 
-    it('should do a basic legacy pegin using p2sh-segwit sender with the exact minimum value', async () => {
+      it('should do a basic legacy pegin using p2sh-segwit sender with the exact minimum value', async () => {
 
-      // Arrange
+        // Arrange
 
-      const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
-      const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper, 'p2sh-segwit');
-      const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
-      const peginValueInSatoshis = minimumPeginValueInSatoshis;
+        const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
+        const senderRecipientInfo = await createSenderRecipientInfo(rskTxHelper, btcTxHelper, 'p2sh-segwit');
+        const initialSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+        const peginValueInSatoshis = minimumPeginValueInSatoshis;
 
-      // Act
+        // Act
 
-      const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, satoshisToBtc(peginValueInSatoshis));
-      
-      // Assert
+        const btcPeginTxHash = await sendPegin(rskTxHelper, btcTxHelper, senderRecipientInfo.btcSenderAddressInfo, satoshisToBtc(peginValueInSatoshis));
+        
+        // Assert
 
-      await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash);
+        await ensurePeginIsRegistered(rskTxHelper, btcPeginTxHash);
 
-      await assertExpectedPeginBtcEventIsEmitted(btcPeginTxHash, senderRecipientInfo.rskRecipientRskAddressInfo.address, peginValueInSatoshis);
+        await assertExpectedPeginBtcEventIsEmitted(btcPeginTxHash, senderRecipientInfo.rskRecipientRskAddressInfo.address, peginValueInSatoshis);
 
-      await assert2wpBalancesAfterSuccessfulPegin(initial2wpBalances, peginValueInSatoshis);
+        await assert2wpBalancesAfterSuccessfulPegin(initial2wpBalances, peginValueInSatoshis);
 
-      // The btc sender address balance is decreased by the pegin value and the btc fee
-      const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
-      expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
+        // The btc sender address balance is decreased by the pegin value and the btc fee
+        const finalSenderAddressBalanceInSatoshis = await getBtcAddressBalanceInSatoshis(btcTxHelper, senderRecipientInfo.btcSenderAddressInfo.address);
+        expect(finalSenderAddressBalanceInSatoshis).to.be.equal(initialSenderAddressBalanceInSatoshis - peginValueInSatoshis - btcFeeInSatoshis);
 
-      // The recipient rsk address balance is increased by the pegin value
-      const finalRskRecipientBalanceInWeisBN = await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address);
-      const expectedRskRecipientBalancesInWeisBN = new BN(satoshisToWeis(peginValueInSatoshis));
-      expect(finalRskRecipientBalanceInWeisBN.eq(expectedRskRecipientBalancesInWeisBN)).to.be.true;
+        // The recipient rsk address balance is increased by the pegin value
+        const finalRskRecipientBalanceInWeisBN = await rskTxHelper.getBalance(senderRecipientInfo.rskRecipientRskAddressInfo.address);
+        const expectedRskRecipientBalancesInWeisBN = new BN(satoshisToWeis(peginValueInSatoshis));
+        expect(finalRskRecipientBalanceInWeisBN.eq(expectedRskRecipientBalancesInWeisBN)).to.be.true;
+
+      });
 
     });
 

--- a/lib/tests/2wp.js
+++ b/lib/tests/2wp.js
@@ -46,7 +46,7 @@ const execute = (description, getRskHost) => {
 
     });
 
-    describe('Pegin test', () => {
+    describe('Pegin tests', () => {
 
       it('should do a basic legacy pegin with the exact minimum value', async () => {
 


### PR DESCRIPTION
Put all pegin tests in their own test suite.
No changes to the tests were made, they were just put inside a `describe('Pegin test', () => { ... });` test suite.