### PR TITLE
Disable rskip427 temporarily

### DIFF
--- a/test.js
+++ b/test.js
@@ -215,7 +215,7 @@ before(async () => {
       config.customConfig[`federator.amountOfHeadersToSend`] = 500;
       
       // TODO: Remove once RIT refactors have been completed
-      config.customConfig[`blockchain.config.consensusRules.rskip417`] = -1;
+      config.customConfig[`blockchain.config.consensusRules.rskip427`] = -1;
 
       // federatesToStart: [1, 2, 3]
       // additionalFederateNodes: [4, 5]

--- a/test.js
+++ b/test.js
@@ -214,6 +214,9 @@ before(async () => {
       // Set amountOfHeadersToSend to 500 to avoid having to inform headers in separated calls
       config.customConfig[`federator.amountOfHeadersToSend`] = 500;
       
+      // TODO: Remove once RIT refactors have been completed
+      config.customConfig[`blockchain.config.consensusRules.rskip417`] = -1;
+
       // federatesToStart: [1, 2, 3]
       // additionalFederateNodes: [4, 5]
       // Configure peers


### PR DESCRIPTION
Disabling RSKIP427 temporarily since the implementation is not compatible with the current tests. Tests for the changes implemented in RSKIP427 will be implemented as part of the ongoing refactor to the RITs

`rskj:rskip427-integration`