### PR TITLE
Fixing the use of RIT branch instead of hardcoded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,16 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      rskj-branch:
+        description: 'Branch for RSKj'
+        required: false
+        default: 'master'
+      powpeg-branch:
+        description: 'Branch for PowPeg Node'
+        required: false
+        default: 'master'
 
 permissions:
   contents: read
@@ -47,12 +57,86 @@ jobs:
           load: true
           tags: ${{ env.TEST_TAG }}
 
+      - name: Set Branch Variables
+        id: set-branch-variables
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github_event_inputs_powpeg_branch: ${{ github.event.inputs.powpeg-branch }}
+          github_event_inputs_rskj_branch: ${{ github.event.inputs.rskj-branch }}
+          github_event_name: ${{ github.event_name }}
+          github_event_pull_request_number: ${{ github.event.pull_request.number }}
+          github_head_ref: ${{ github.head_ref }}
+          github_ref_name: ${{ github.ref_name }}
+        run: |
+          PR_DESCRIPTION=pr-description.txt
+
+          ALLOWED_BRANCH_CHARACTERS='[-+./0-9A-Z_a-z]'
+
+          default_rskj_branch=master
+          default_powpeg_branch=master
+          default_rit_branch=main
+
+          get_branch_from_description()
+          {
+            _prefix=$1
+
+            # On lines matching "`$_prefix:...`", replace the lines with the
+            # thing in ... and print the result.
+            _search_re='\@`'$_prefix:$ALLOWED_BRANCH_CHARACTERS'\{1,\}`@'
+            _replace_re='s@.*`'$_prefix:'\('$ALLOWED_BRANCH_CHARACTERS'\{1,\}\)`.*@\1@p'
+            _branch=$(sed -n "$_search_re $_replace_re" "$PR_DESCRIPTION")
+            echo "$_branch"
+          }
+
+          is_valid_branch_name()
+          {
+            echo "$1" | grep -qx "$ALLOWED_BRANCH_CHARACTERS\\{1,\\}"
+          }
+
+          if [ "$github_event_name" = workflow_dispatch ]; then
+            RSKJ_BRANCH=${github_event_inputs_rskj_branch:-$default_rit_branch}
+            POWPEG_BRANCH=${github_event_inputs_powpeg_branch:-$default_powpeg_branch}
+            RIT_BRANCH=$github_ref_name
+          elif [ "$github_event_name" = pull_request ]; then
+            gh pr view "$github_event_pull_request_number" --json body -q .body >"$PR_DESCRIPTION"
+
+            RSKJ_BRANCH=$(get_branch_from_description rskj)
+            : ${RSKJ_BRANCH:=$default_rskj_branch}
+
+            POWPEG_BRANCH=$(get_branch_from_description fed)
+            : ${POWPEG_BRANCH:=$default_powpeg_branch}
+
+            RIT_BRANCH=$(get_branch_from_description rit)
+            : ${RIT_BRANCH:=${github_head_ref:-$default_rskj_branch}}
+          else
+            RSKJ_BRANCH=$default_rskj_branch
+            POWPEG_BRANCH=$default_powpeg_branch
+            RIT_BRANCH=$default_rit_branch
+          fi
+
+          if ! is_valid_branch_name "$RSKJ_BRANCH"; then
+            echo "rskj: invalid branch name: $RSKJ_BRANCH" >&2
+            exit 1
+          fi
+          if ! is_valid_branch_name "$POWPEG_BRANCH"; then
+            echo "fed: invalid branch name: $POWPEG_BRANCH" >&2
+            exit 1
+          fi
+          if ! is_valid_branch_name "$RIT_BRANCH"; then
+            echo "rit: invalid branch name: $RIT_BRANCH" >&2
+            exit 1
+          fi
+
+          echo "RSKJ_BRANCH=$RSKJ_BRANCH" >> $GITHUB_ENV
+          echo "RIT_BRANCH=$RIT_BRANCH" >> $GITHUB_ENV
+          echo "POWPEG_BRANCH=$POWPEG_BRANCH" >> $GITHUB_ENV
+
       - name: Test the RIT Container Action
         id: test-container
         env:
-          INPUT_RSKJ_BRANCH: master
-          INPUT_POWPEG_NODE_BRANCH: master
-          INPUT_RIT_BRANCH: main
+          INPUT_RSKJ_BRANCH: ${{ env.RSKJ_BRANCH }}
+          INPUT_POWPEG_NODE_BRANCH: ${{ env.POWPEG_BRANCH }}
+          INPUT_RIT_BRANCH: ${{ env.RIT_BRANCH }}
           INPUT_RIT_LOG_LEVEL: info
         run: |
           docker run \
@@ -95,8 +179,10 @@ jobs:
         id: test-rit-action
         uses: ./
         with:
-          rskj-branch: master
-          powpeg-node-branch: master
+          rskj-branch: ${{ env.RSKJ_BRANCH }}
+          powpeg-node-branch: ${{ env.POWPEG_BRANCH }}
+          rit-branch: ${{ env.RIT_BRANCH }}
+
 
       - name: Print RIT Status and Message
         id: output


### PR DESCRIPTION
Adding the configuration of branches from PR and configurable and removing the hardcoded.

`rskj:snap-v4-final`
