### PR TITLE
Removes intermediate 2wp test execution since it is not needed.

### DIFF
--- a/tests/02_00_01-2wp.js
+++ b/tests/02_00_01-2wp.js
@@ -1,3 +1,0 @@
-const twoWpTests = require('../lib/tests/2wp');
-
-twoWpTests.execute('BTC <=> RSK 2WP', () => Runners.hosts.federate.host);


### PR DESCRIPTION
Removes intermediate 2wp test execution since it is not needed. Nothing special has changed until this execution, so, no need to run it again. It will run again after the next federation change.