### PR TITLE
Fix container publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
     name: Test  RIT Action docker container-action
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      packages: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Reinstantiate package write permission for the job that published the
container into ghcr.
