### PR TITLE
Saving branch names in output to be used by next job

### DIFF
--- a/.github/actions/set-branch-variables/action.yml
+++ b/.github/actions/set-branch-variables/action.yml
@@ -1,0 +1,72 @@
+name: "Set Branch Variables"
+description: "Extract branch variables and export them as environment variables"
+inputs:
+  token:
+    description: "GitHub token"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Set Branch Variables
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        github_event_inputs_powpeg_branch: ${{ github.event.inputs.powpeg-branch }}
+        github_event_inputs_rskj_branch: ${{ github.event.inputs.rskj-branch }}
+        github_event_name: ${{ github.event_name }}
+        github_event_pull_request_number: ${{ github.event.pull_request.number }}
+        github_head_ref: ${{ github.head_ref }}
+        github_ref_name: ${{ github.ref_name }}
+      run: |
+        PR_DESCRIPTION=pr-description.txt
+        ALLOWED_BRANCH_CHARACTERS='[-+./0-9A-Z_a-z]'
+        default_rskj_branch=master
+        default_powpeg_branch=master
+        default_rit_branch=main
+
+        get_branch_from_description() {
+          _prefix=$1
+          _search_re='\@`'$_prefix:$ALLOWED_BRANCH_CHARACTERS'\{1,\}`@'
+          _replace_re='s@.*`'$_prefix:'\('$ALLOWED_BRANCH_CHARACTERS'\{1,\}\)`.*@\1@p'
+          _branch=$(sed -n "$_search_re $_replace_re" "$PR_DESCRIPTION")
+          echo "$_branch"
+        }
+
+        is_valid_branch_name() {
+          echo "$1" | grep -qx "$ALLOWED_BRANCH_CHARACTERS\\{1,\\}"
+        }
+
+        if [ "$github_event_name" = workflow_dispatch ]; then
+          RSKJ_BRANCH=${github_event_inputs_rskj_branch:-$default_rit_branch}
+          POWPEG_BRANCH=${github_event_inputs_powpeg_branch:-$default_powpeg_branch}
+          RIT_BRANCH=$github_ref_name
+        elif [ "$github_event_name" = pull_request ]; then
+          gh pr view "$github_event_pull_request_number" --json body -q .body >"$PR_DESCRIPTION"
+          RSKJ_BRANCH=$(get_branch_from_description rskj)
+          : ${RSKJ_BRANCH:=$default_rskj_branch}
+          POWPEG_BRANCH=$(get_branch_from_description fed)
+          : ${POWPEG_BRANCH:=$default_powpeg_branch}
+          RIT_BRANCH=$(get_branch_from_description rit)
+          : ${RIT_BRANCH:=${github_head_ref:-$default_rskj_branch}}
+        else
+          RSKJ_BRANCH=$default_rskj_branch
+          POWPEG_BRANCH=$default_powpeg_branch
+          RIT_BRANCH=$default_rit_branch
+        fi
+
+        if ! is_valid_branch_name "$RSKJ_BRANCH"; then
+          echo "rskj: invalid branch name: $RSKJ_BRANCH" >&2
+          exit 1
+        fi
+        if ! is_valid_branch_name "$POWPEG_BRANCH"; then
+          echo "fed: invalid branch name: $POWPEG_BRANCH" >&2
+          exit 1
+        fi
+        if ! is_valid_branch_name "$RIT_BRANCH"; then
+          echo "rit: invalid branch name: $RIT_BRANCH" >&2
+          exit 1
+        fi
+        
+        echo "RSKJ_BRANCH=$RSKJ_BRANCH" >> $GITHUB_ENV
+        echo "RIT_BRANCH=$RIT_BRANCH" >> $GITHUB_ENV
+        echo "POWPEG_BRANCH=$POWPEG_BRANCH" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,14 @@ on:
 
 permissions:
   contents: read
-  
+
 env:
   TEST_TAG:  ${{ github.event.repository.name }}/rit:test
   LATEST_TAG: ghcr.io/rsksmart/${{ github.event.repository.name }}/rit
 
 jobs:
   build-push-rit-action-container-action:
-    name: Test  RIT Action docker container-action
+    name: Test RIT Action docker container-action
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -59,96 +59,28 @@ jobs:
           load: true
           tags: ${{ env.TEST_TAG }}
 
+      # Call the composite action to set branch variables
       - name: Set Branch Variables
-        id: set-branch-variables
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          github_event_inputs_powpeg_branch: ${{ github.event.inputs.powpeg-branch }}
-          github_event_inputs_rskj_branch: ${{ github.event.inputs.rskj-branch }}
-          github_event_name: ${{ github.event_name }}
-          github_event_pull_request_number: ${{ github.event.pull_request.number }}
-          github_head_ref: ${{ github.head_ref }}
-          github_ref_name: ${{ github.ref_name }}
-        run: |
-          PR_DESCRIPTION=pr-description.txt
-
-          ALLOWED_BRANCH_CHARACTERS='[-+./0-9A-Z_a-z]'
-
-          default_rskj_branch=master
-          default_powpeg_branch=master
-          default_rit_branch=main
-
-          get_branch_from_description()
-          {
-            _prefix=$1
-
-            # On lines matching "`$_prefix:...`", replace the lines with the
-            # thing in ... and print the result.
-            _search_re='\@`'$_prefix:$ALLOWED_BRANCH_CHARACTERS'\{1,\}`@'
-            _replace_re='s@.*`'$_prefix:'\('$ALLOWED_BRANCH_CHARACTERS'\{1,\}\)`.*@\1@p'
-            _branch=$(sed -n "$_search_re $_replace_re" "$PR_DESCRIPTION")
-            echo "$_branch"
-          }
-
-          is_valid_branch_name()
-          {
-            echo "$1" | grep -qx "$ALLOWED_BRANCH_CHARACTERS\\{1,\\}"
-          }
-
-          if [ "$github_event_name" = workflow_dispatch ]; then
-            RSKJ_BRANCH=${github_event_inputs_rskj_branch:-$default_rit_branch}
-            POWPEG_BRANCH=${github_event_inputs_powpeg_branch:-$default_powpeg_branch}
-            RIT_BRANCH=$github_ref_name
-          elif [ "$github_event_name" = pull_request ]; then
-            gh pr view "$github_event_pull_request_number" --json body -q .body >"$PR_DESCRIPTION"
-
-            RSKJ_BRANCH=$(get_branch_from_description rskj)
-            : ${RSKJ_BRANCH:=$default_rskj_branch}
-
-            POWPEG_BRANCH=$(get_branch_from_description fed)
-            : ${POWPEG_BRANCH:=$default_powpeg_branch}
-
-            RIT_BRANCH=$(get_branch_from_description rit)
-            : ${RIT_BRANCH:=${github_head_ref:-$default_rskj_branch}}
-          else
-            RSKJ_BRANCH=$default_rskj_branch
-            POWPEG_BRANCH=$default_powpeg_branch
-            RIT_BRANCH=$default_rit_branch
-          fi
-
-          if ! is_valid_branch_name "$RSKJ_BRANCH"; then
-            echo "rskj: invalid branch name: $RSKJ_BRANCH" >&2
-            exit 1
-          fi
-          if ! is_valid_branch_name "$POWPEG_BRANCH"; then
-            echo "fed: invalid branch name: $POWPEG_BRANCH" >&2
-            exit 1
-          fi
-          if ! is_valid_branch_name "$RIT_BRANCH"; then
-            echo "rit: invalid branch name: $RIT_BRANCH" >&2
-            exit 1
-          fi
-          
-          echo "::set-output name=RSKJ_BRANCH::$RSKJ_BRANCH"
-          echo "::set-output name=RIT_BRANCH::$RIT_BRANCH"
-          echo "::set-output name=POWPEG_BRANCH::$POWPEG_BRANCH"
+        uses: ./.github/actions/set-branch-variables
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test the RIT Container Action
         id: test-container
         env:
-          INPUT_RSKJ_BRANCH: ${{ steps.set-branch-variables.outputs.RSKJ_BRANCH }}
-          INPUT_POWPEG_NODE_BRANCH: ${{ steps.set-branch-variables.outputs.POWPEG_BRANCH }}
-          INPUT_RIT_BRANCH: ${{steps.set-branch-variables.outputs.RIT_BRANCH }}
+          INPUT_RSKJ_BRANCH: ${{ env.RSKJ_BRANCH }}
+          INPUT_POWPEG_NODE_BRANCH: ${{ env.POWPEG_BRANCH }}
+          INPUT_RIT_BRANCH: ${{ env.RIT_BRANCH }}
           INPUT_RIT_LOG_LEVEL: info
         run: |
           docker run \
-          --env GITHUB_OUTPUT="/github-output"  \
-          --env INPUT_RSKJ_BRANCH="${{ env.INPUT_RSKJ_BRANCH }}"  \
-          --env INPUT_POWPEG_NODE_BRANCH="${{ env.INPUT_POWPEG_NODE_BRANCH }}"  \
-          --env INPUT_RIT_BRANCH="${{ env.INPUT_RIT_BRANCH }}"  \
-          --env INPUT_RIT_LOG_LEVEL="${{ env.INPUT_RIT_LOG_LEVEL }}" \
-          -v "$GITHUB_OUTPUT:/github-output"  \
-          --rm ${{ env.TEST_TAG }} 
+            --env GITHUB_OUTPUT="/github-output"  \
+            --env INPUT_RSKJ_BRANCH="${{ env.RSKJ_BRANCH }}"  \
+            --env INPUT_POWPEG_NODE_BRANCH="${{ env.POWPEG_BRANCH }}"  \
+            --env INPUT_RIT_BRANCH="${{ env.RIT_BRANCH }}"  \
+            --env INPUT_RIT_LOG_LEVEL="${{ env.INPUT_RIT_LOG_LEVEL }}" \
+            -v "$GITHUB_OUTPUT:/github-output"  \
+            --rm ${{ env.TEST_TAG }}
 
       - name: GitHub container registry login
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
@@ -167,7 +99,7 @@ jobs:
           push: true
 
   test-rit-action:
-    needs:  build-push-rit-action-container-action
+    needs: build-push-rit-action-container-action
     name: GitHub Actions Test
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -177,13 +109,19 @@ jobs:
         id: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      # Call the composite action here to set branch variables
+      - name: Set Branch Variables
+        uses: ./.github/actions/set-branch-variables
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Test RIT Action
         id: test-rit-action
         uses: ./
         with:
-          rskj-branch: ${{ needs.build-push-rit-action-container-action.outputs.RSKJ_BRANCH }}
-          powpeg-node-branch: ${{ needs.build-push-rit-action-container-action.outputs.POWPEG_BRANCH }}
-          rit-branch: ${{ needs.build-push-rit-action-container-action.outputs.RIT_BRANCH }}
+          rskj-branch: ${{ env.RSKJ_BRANCH }}
+          powpeg-node-branch: ${{ env.POWPEG_BRANCH }}
+          rit-branch: ${{ env.RIT_BRANCH }}
 
       - name: Print RIT Status and Message
         id: output
@@ -192,13 +130,13 @@ jobs:
           echo "RIT Message = ${{ steps.test-rit-action.outputs.message }}"
 
   publish-rit-action-tag:
-    needs:  test-rit-action
+    needs: test-rit-action
     name: Publish RIT Action tag
     runs-on: ubuntu-latest
     timeout-minutes: 60
     if: github.ref == 'refs/heads/main'
     permissions:
-      contents:  write
+      contents: write
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
           push: true
 
   test-rit-action:
+    if: ${{ github.ref == 'refs/heads/main' }}
     needs: build-push-rit-action-container-action
     name: GitHub Actions Test
     runs-on: ubuntu-latest
@@ -130,11 +131,11 @@ jobs:
           echo "RIT Message = ${{ steps.test-rit-action.outputs.message }}"
 
   publish-rit-action-tag:
+    if: github.ref == 'refs/heads/main'
     needs: test-rit-action
     name: Publish RIT Action tag
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    if: github.ref == 'refs/heads/main'
     permissions:
       contents: write
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,10 @@ jobs:
           echo "RIT_BRANCH=$RIT_BRANCH" >> $GITHUB_ENV
           echo "POWPEG_BRANCH=$POWPEG_BRANCH" >> $GITHUB_ENV
 
+          echo "RSKJ_BRANCH=$RSKJ_BRANCH" >> $GITHUB_OUTPUT
+          echo "RIT_BRANCH=$RIT_BRANCH" >> $GITHUB_OUTPUT
+          echo "POWPEG_BRANCH=$POWPEG_BRANCH" >> $GITHUB_OUTPUT
+
       - name: Test the RIT Container Action
         id: test-container
         env:
@@ -181,10 +185,9 @@ jobs:
         id: test-rit-action
         uses: ./
         with:
-          rskj-branch: ${{ env.RSKJ_BRANCH }}
-          powpeg-node-branch: ${{ env.POWPEG_BRANCH }}
-          rit-branch: ${{ env.RIT_BRANCH }}
-
+          rskj-branch: ${{ needs.build-push-rit-action-container-action.outputs.RSKJ_BRANCH }}
+          powpeg-node-branch: ${{ needs.build-push-rit-action-container-action.outputs.POWPEG_BRANCH }}
+          rit-branch: ${{ needs.build-push-rit-action-container-action.outputs.RIT_BRANCH }}
 
       - name: Print RIT Status and Message
         id: output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,21 +128,17 @@ jobs:
             echo "rit: invalid branch name: $RIT_BRANCH" >&2
             exit 1
           fi
-
-          echo "RSKJ_BRANCH=$RSKJ_BRANCH" >> $GITHUB_ENV
-          echo "RIT_BRANCH=$RIT_BRANCH" >> $GITHUB_ENV
-          echo "POWPEG_BRANCH=$POWPEG_BRANCH" >> $GITHUB_ENV
-
-          echo "RSKJ_BRANCH=$RSKJ_BRANCH" >> $GITHUB_OUTPUT
-          echo "RIT_BRANCH=$RIT_BRANCH" >> $GITHUB_OUTPUT
-          echo "POWPEG_BRANCH=$POWPEG_BRANCH" >> $GITHUB_OUTPUT
+          
+          echo "::set-output name=RSKJ_BRANCH::$RSKJ_BRANCH"
+          echo "::set-output name=RIT_BRANCH::$RIT_BRANCH"
+          echo "::set-output name=POWPEG_BRANCH::$POWPEG_BRANCH"
 
       - name: Test the RIT Container Action
         id: test-container
         env:
-          INPUT_RSKJ_BRANCH: ${{ env.RSKJ_BRANCH }}
-          INPUT_POWPEG_NODE_BRANCH: ${{ env.POWPEG_BRANCH }}
-          INPUT_RIT_BRANCH: ${{ env.RIT_BRANCH }}
+          INPUT_RSKJ_BRANCH: ${{ steps.set-branch-variables.outputs.RSKJ_BRANCH }}
+          INPUT_POWPEG_NODE_BRANCH: ${{ steps.set-branch-variables.outputs.POWPEG_BRANCH }}
+          INPUT_RIT_BRANCH: ${{steps.set-branch-variables.outputs.RIT_BRANCH }}
           INPUT_RIT_LOG_LEVEL: info
         run: |
           docker run \


### PR DESCRIPTION
Attempt to fix broken build in branch names, like happened [here](https://github.com/rsksmart/rootstock-integration-tests/actions/runs/13796398960/job/38590675210?pr=226).