### PR TITLE
Refactor btc to rsk client

### DIFF
--- a/lib/tests/2wp.js
+++ b/lib/tests/2wp.js
@@ -21,8 +21,8 @@ const { assert2wpBalancesAfterSuccessfulPegin } = require('../assertions/2wp');
 const BridgeTransactionParser = require('@rsksmart/bridge-transaction-parser');
 const {
     PEGIN_REJECTION_REASONS,
-    PEGIN_UNREFUNDABLE_REASONS,
     PEGIN_V1_RSKT_PREFIX_HEX,
+    PEGIN_EVENTS
 } = require('../constants/pegin-constants');
 const {
     PEGOUT_EVENTS,
@@ -782,7 +782,7 @@ const execute = (description) => {
                 ).to.be.true;
             });
 
-            it('should reject and not refund a legacy pegin from a bech32 sender with the value exactly minimum', async () => {
+            it('should not inform a legacy pegin from a bech32 sender with the value exactly minimum', async () => {
                 // Arrange
 
                 const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
@@ -810,18 +810,8 @@ const execute = (description) => {
                 await triggerRelease(rskTxHelpers, btcTxHelper, {}, false);
 
                 await assertPeginTxHashNotProcessed(btcPeginTxHash);
-
-                // Two events are emitted in this scenario: rejected_pegin and unrefundable_pegin.
-                await assertExpectedRejectedPeginEventIsEmitted(
-                    btcPeginTxHash,
-                    blockNumberBeforePegin,
-                    PEGIN_REJECTION_REASONS.LEGACY_PEGIN_UNDETERMINED_SENDER
-                );
-                await assertExpectedUnrefundablePeginEventIsEmitted(
-                    btcPeginTxHash,
-                    blockNumberBeforePegin,
-                    PEGIN_UNREFUNDABLE_REASONS.LEGACY_PEGIN_UNDETERMINED_SENDER
-                );
+                // Since we are not informing the pegin, no events are emitted in this scenario
+                await assertNoPeginEventsAreEmitted(btcPeginTxHash, blockNumberBeforePegin);
 
                 // Expecting the multisig btc sender balance to be zero after the pegin.
                 const senderAddressBalanceAfterPegin = await getBtcAddressBalanceInSatoshis(
@@ -1911,23 +1901,24 @@ const assertExpectedRejectedPeginEventIsEmitted = async (
     expect(rejectedPeginEvent).to.be.deep.equal(expectedEvent);
 };
 
-const assertExpectedUnrefundablePeginEventIsEmitted = async (
+const assertNoPeginEventsAreEmitted = async (
     btcPeginTxHash,
-    blockNumberBeforePegin,
-    rejectionReason
+    blockNumberBeforePegin
 ) => {
-    const expectedEvent = createExpectedUnrefundablePeginEvent(btcPeginTxHash, rejectionReason);
     const currentBlockNumber = await rskTxHelper.getBlockNumber();
-    const rejectedPeginEvent = await findEventInBlock(
-        rskTxHelper,
-        expectedEvent.name,
-        blockNumberBeforePegin,
-        currentBlockNumber,
-        (foundEvent) => {
-            return foundEvent.arguments.btcTxHash === ensure0x(btcPeginTxHash);
-        }
-    );
-    expect(rejectedPeginEvent).to.be.deep.equal(expectedEvent);
+    for (const { name: eventName } of Object.values(PEGIN_EVENTS)) {
+        const found = await findEventInBlock(
+            rskTxHelper,
+            eventName,
+            blockNumberBeforePegin,
+            currentBlockNumber,
+            (ev) => ev.arguments.btcTxHash === ensure0x(btcPeginTxHash)
+        );
+        expect(
+            found,
+            `No bridge ${eventName} event should be emitted for btc tx ${btcPeginTxHash}`
+        ).to.be.null;
+    }
 };
 
 const assertExpectedReleaseRequestedEventIsEmitted = async (

--- a/lib/tests/change-federation.js
+++ b/lib/tests/change-federation.js
@@ -1212,6 +1212,7 @@ const execute = (description, newFederationConfig, segwitToSegwitFederationChang
         });
 
         it('should migrate utxos', async () => {
+            const rskTxHelper = rskTxHelpers[rskTxHelpers.length - 1];
             const bridgeStateBeforeMigration = await getBridgeState(rskTxHelper.getClient());
 
             expect(bridgeStateBeforeMigration.pegoutsWaitingForConfirmations.length).to.be.equal(
@@ -1258,8 +1259,6 @@ const execute = (description, newFederationConfig, segwitToSegwitFederationChang
 
             await wait(1000);
             await rskUtils.waitAndUpdateBridge(rskTxHelper);
-            const lastFederator = rskTxHelpers[rskTxHelpers.length - 1];
-            await rskUtils.waitAndUpdateBridge(lastFederator);
 
             const blockNumberBeforeMigrationRelease = await rskTxHelper.getBlockNumber();
 
@@ -1272,7 +1271,7 @@ const execute = (description, newFederationConfig, segwitToSegwitFederationChang
                     return true;
                 }
                 await wait(1000);
-                await rskUtils.waitAndUpdateBridge(rskTxHelpers[rskTxHelpers.length - 1]);
+                await rskUtils.waitAndUpdateBridge(rskTxHelper);
                 return false;
             };
 


### PR DESCRIPTION
- Only active federators should call to register migration tx

`rit:refactor-btc-to-rsk-client`
`fed:powpeg-refactors-integration`