### PR TITLE
Refactor federator registration and update pegin rejection tests

### DIFF
--- a/lib/tests/2wp.js
+++ b/lib/tests/2wp.js
@@ -21,8 +21,8 @@ const { assert2wpBalancesAfterSuccessfulPegin } = require('../assertions/2wp');
 const BridgeTransactionParser = require('@rsksmart/bridge-transaction-parser');
 const {
     PEGIN_REJECTION_REASONS,
-    PEGIN_UNREFUNDABLE_REASONS,
     PEGIN_V1_RSKT_PREFIX_HEX,
+    PEGIN_EVENTS
 } = require('../constants/pegin-constants');
 const {
     PEGOUT_EVENTS,
@@ -782,7 +782,7 @@ const execute = (description) => {
                 ).to.be.true;
             });
 
-            it('should reject and not refund a legacy pegin from a bech32 sender with the value exactly minimum', async () => {
+            it('should not inform a legacy pegin from a bech32 sender with the value exactly minimum', async () => {
                 // Arrange
 
                 const initial2wpBalances = await get2wpBalances(rskTxHelper, btcTxHelper);
@@ -810,18 +810,8 @@ const execute = (description) => {
                 await triggerRelease(rskTxHelpers, btcTxHelper, {}, false);
 
                 await assertPeginTxHashNotProcessed(btcPeginTxHash);
-
-                // Two events are emitted in this scenario: rejected_pegin and unrefundable_pegin.
-                await assertExpectedRejectedPeginEventIsEmitted(
-                    btcPeginTxHash,
-                    blockNumberBeforePegin,
-                    PEGIN_REJECTION_REASONS.LEGACY_PEGIN_UNDETERMINED_SENDER
-                );
-                await assertExpectedUnrefundablePeginEventIsEmitted(
-                    btcPeginTxHash,
-                    blockNumberBeforePegin,
-                    PEGIN_UNREFUNDABLE_REASONS.LEGACY_PEGIN_UNDETERMINED_SENDER
-                );
+                // Since we are not informing the pegin, no events are emitted in this scenario
+                await assertNoPeginEventsAreEmitted(btcPeginTxHash, blockNumberBeforePegin);
 
                 // Expecting the multisig btc sender balance to be zero after the pegin.
                 const senderAddressBalanceAfterPegin = await getBtcAddressBalanceInSatoshis(
@@ -1911,23 +1901,24 @@ const assertExpectedRejectedPeginEventIsEmitted = async (
     expect(rejectedPeginEvent).to.be.deep.equal(expectedEvent);
 };
 
-const assertExpectedUnrefundablePeginEventIsEmitted = async (
+const assertNoPeginEventsAreEmitted = async (
     btcPeginTxHash,
-    blockNumberBeforePegin,
-    rejectionReason
+    blockNumberBeforePegin
 ) => {
-    const expectedEvent = createExpectedUnrefundablePeginEvent(btcPeginTxHash, rejectionReason);
     const currentBlockNumber = await rskTxHelper.getBlockNumber();
-    const rejectedPeginEvent = await findEventInBlock(
-        rskTxHelper,
-        expectedEvent.name,
-        blockNumberBeforePegin,
-        currentBlockNumber,
-        (foundEvent) => {
-            return foundEvent.arguments.btcTxHash === ensure0x(btcPeginTxHash);
-        }
-    );
-    expect(rejectedPeginEvent).to.be.deep.equal(expectedEvent);
+    for (const { name: eventName } of Object.values(PEGIN_EVENTS)) {
+        const found = await findEventInBlock(
+            rskTxHelper,
+            eventName,
+            blockNumberBeforePegin,
+            currentBlockNumber,
+            (ev) => ev.arguments.btcTxHash === ensure0x(btcPeginTxHash)
+        );
+        expect(
+            found,
+            `No bridge ${eventName} event should be emitted for btc tx ${btcPeginTxHash}`
+        ).to.be.null;
+    }
 };
 
 const assertExpectedReleaseRequestedEventIsEmitted = async (

--- a/lib/tests/change-federation.js
+++ b/lib/tests/change-federation.js
@@ -1212,6 +1212,7 @@ const execute = (description, newFederationConfig, segwitToSegwitFederationChang
         });
 
         it('should migrate utxos', async () => {
+            const rskTxHelper = rskTxHelpers[rskTxHelpers.length - 1];
             const bridgeStateBeforeMigration = await getBridgeState(rskTxHelper.getClient());
 
             expect(bridgeStateBeforeMigration.pegoutsWaitingForConfirmations.length).to.be.equal(
@@ -1258,8 +1259,6 @@ const execute = (description, newFederationConfig, segwitToSegwitFederationChang
 
             await wait(1000);
             await rskUtils.waitAndUpdateBridge(rskTxHelper);
-            const lastFederator = rskTxHelpers[rskTxHelpers.length - 1];
-            await rskUtils.waitAndUpdateBridge(lastFederator);
 
             const blockNumberBeforeMigrationRelease = await rskTxHelper.getBlockNumber();
 
@@ -1272,7 +1271,7 @@ const execute = (description, newFederationConfig, segwitToSegwitFederationChang
                     return true;
                 }
                 await wait(1000);
-                await rskUtils.waitAndUpdateBridge(rskTxHelpers[rskTxHelpers.length - 1]);
+                await rskUtils.waitAndUpdateBridge(rskTxHelper);
                 return false;
             };
 


### PR DESCRIPTION
This pull request updates the test suites for the 2-way peg (2wp) and federation migration logic, mainly to improve test accuracy and maintainability. The most significant change is the refactoring of legacy pegin tests so that, when a legacy pegin from a bech32 sender with the minimum value is not informed, the test now checks that no bridge events are emitted, rather than expecting specific rejection and unrefundable events. Additionally, the federation migration tests are clarified by consistently using the correct transaction helper.

### 2wp legacy pegin event handling improvements

* Refactored the legacy pegin test to assert that no pegin events are emitted (using `assertNoPeginEventsAreEmitted`) instead of checking for both `rejected_pegin` and `unrefundable_pegin` events, aligning the test with the intended behavior for uninformed pegins. [[1]](diffhunk://#diff-530dff31017eb3e951f3872538c0ad19594ae9ce04870a05b9f8029fc16225aeL785-R785) [[2]](diffhunk://#diff-530dff31017eb3e951f3872538c0ad19594ae9ce04870a05b9f8029fc16225aeL813-R814) [[3]](diffhunk://#diff-530dff31017eb3e951f3872538c0ad19594ae9ce04870a05b9f8029fc16225aeL1914-R1921)
* Removed the unused `PEGIN_UNREFUNDABLE_REASONS` constant import from the test file, since unrefundable events are no longer expected in this case.

### Federation migration test improvements

* Ensured consistent usage of the correct `rskTxHelper` instance throughout the federation migration test, improving clarity and correctness. [[1]](diffhunk://#diff-7c78c42a8f71b13a8f953353e89fbede3d5384cabc27eb7987dafff59e68e46aR1215) [[2]](diffhunk://#diff-7c78c42a8f71b13a8f953353e89fbede3d5384cabc27eb7987dafff59e68e46aL1261-L1262) [[3]](diffhunk://#diff-7c78c42a8f71b13a8f953353e89fbede3d5384cabc27eb7987dafff59e68e46aL1275-R1274)