### PR TITLE
Changing RIT to make rskj repo configurable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
     required: false
     default: 'rskj'
   github-token:
-    description: 'Token used to clone a private base rskj repository. Optional; only required when rskj-repo is private. Pass it via GitHub Actions secrets (e.g. secrets.MY_TOKEN) and do not hardcode.'
+    description: 'Token used to clone a private base rskj repository. Optional; only required when rskj-repo is private. Pass it via GitHub Actions secrets (e.g. ${{ secrets.MY_TOKEN }}) and do not hardcode.'
     required: false
     default: ''
 

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
     required: false
     default: 'rskj'
   github-token:
-    description: 'Token used to clone a private base rskj repository. Optional; only required when rskj-repo is private. Pass it via GitHub Actions secrets (e.g. ${{ secrets.MY_TOKEN }}) — do not hardcode.'
+    description: 'Token used to clone a private base rskj repository. Optional; only required when rskj-repo is private. Pass it via GitHub Actions secrets (e.g. secrets.MY_TOKEN) and do not hardcode.'
     required: false
     default: ''
 

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,14 @@ inputs:
     description: 'The owner of the repository'
     required: false
     default: 'rsksmart'
+  rskj-repo:
+    description: 'The name of the base rskj repository to checkout (e.g. a private fork)'
+    required: false
+    default: 'rskj'
+  github-token:
+    description: 'Token used to clone a private base rskj repository. Optional; only required when rskj-repo is private.'
+    required: false
+    default: ''
 
 outputs:
   status:
@@ -39,3 +47,5 @@ runs:
     INPUT_RIT_BRANCH: ${{ inputs.rit-branch }}
     INPUT_RIT_LOG_LEVEL: ${{ inputs.rit-log-level }}
     INPUT_REPO_OWNER: ${{ inputs.repo-owner }}
+    INPUT_RSKJ_REPO: ${{ inputs.rskj-repo }}
+    INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
     required: false
     default: 'rskj'
   github-token:
-    description: 'Token used to clone a private base rskj repository. Optional; only required when rskj-repo is private.'
+    description: 'Token used to clone a private base rskj repository. Optional; only required when rskj-repo is private. Pass it via GitHub Actions secrets (e.g. ${{ secrets.MY_TOKEN }}) — do not hardcode.'
     required: false
     default: ''
 

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
     required: false
     default: 'rskj'
   github-token:
-    description: 'Token used to clone a private base rskj repository. Optional; only required when rskj-repo is private. Pass it via GitHub Actions secrets (e.g. ${{ secrets.MY_TOKEN }}) and do not hardcode.'
+    description: 'Token used to clone a private base rskj repository. Optional; only required when rskj-repo is private. Pass it from a GitHub Actions secret (reference it with the standard secrets expression, e.g. secrets.MY_TOKEN) and do not hardcode.'
     required: false
     default: ''
 

--- a/container-action/README.md
+++ b/container-action/README.md
@@ -58,3 +58,43 @@ with:
   powpeg-node-branch: master
   rit-branch: main
 ```
+
+## Customising the branches
+
+There are two ways to tell the integration tests which branch (or tag/commit) of
+`rskj`, `powpeg-node` and `rootstock-integration-tests` to check out.
+
+### 1. From the workflow
+
+Pass them explicitly through the `with:` block of the action, as shown in the
+example above (`rskj-branch`, `powpeg-node-branch`, `rit-branch`).
+
+### 2. From the Pull Request description
+
+When the tests are triggered by a pull request, the branches can be overridden
+directly from the **PR description**, without touching any workflow file. This is
+handled by the [`set-branch-variables`](../.github/actions/set-branch-variables/action.yml)
+composite action, which scans the PR body for override tokens.
+
+Each token must be wrapped in backticks and use the `prefix:value` format
+(the backticks and the colon are both required):
+
+- `` `rskj:<branch>` `` — the base rskj branch/tag/commit
+- `` `fed:<branch>` `` — the powpeg-node branch/tag/commit (powpeg is referred to as *fed*)
+- `` `rit:<branch>` `` — the rootstock-integration-tests branch/tag/commit
+
+For example, adding the following anywhere in the PR description runs the tests
+against a custom rskj branch and a specific powpeg tag, while keeping the default
+`rit` branch:
+
+```
+Testing the peg-out changes.
+
+`rskj:my-feature-branch`
+`fed:6.4.0.0-rc`
+```
+
+Notes:
+- Only the characters `[-+./0-9A-Z_a-z]` are allowed in the branch name.
+- Any override that is omitted falls back to its default (`master` for `rskj`
+  and `fed`; for `rit`, the PR's own head branch).

--- a/container-action/README.md
+++ b/container-action/README.md
@@ -98,3 +98,5 @@ Notes:
 - Only the characters `[-+./0-9A-Z_a-z]` are allowed in the branch name.
 - Any override that is omitted falls back to its default (`master` for `rskj`
   and `fed`; for `rit`, the PR's own head branch).
+- To run tests against a fork/private `rskj`, set `repo-owner` (and optionally `rskj-repo`)
+  and provide `github-token` when the repository is private.

--- a/container-action/entrypoint.sh
+++ b/container-action/entrypoint.sh
@@ -81,9 +81,15 @@ cd /usr/src/
 if [[ "$IS_POWPEG_BRANCH" -eq 200 ]]; then
   echo "Found matching branch name in $REPO_OWNER/powpeg-node.git repo"
   git clone "https://github.com/$REPO_OWNER/powpeg-node.git" powpeg
-else
-  echo "Found matching branch name in rsksmart/powpeg-node.git repo"
+elif [[ "$IS_POWPEG_BRANCH" -eq 404 ]]; then
+  # Only a genuine 404 (branch not found in the configured owner) triggers the
+  # fallback to upstream rsksmart/powpeg-node. Any other status (401/403/rate
+  # limit) is treated as a hard error so we never silently switch repos.
+  echo "No branch $POWPEG_NODE_BRANCH in $REPO_OWNER/powpeg-node.git; falling back to default rsksmart/powpeg-node.git repo"
   git clone "https://github.com/rsksmart/powpeg-node.git" powpeg
+else
+  echo "Error: unexpected HTTP status $IS_POWPEG_BRANCH while checking $REPO_OWNER/powpeg-node for branch $POWPEG_NODE_BRANCH (check the token permissions or GitHub rate limits)" >&2
+  exit 1
 fi
 cp configure_gradle_powpeg.sh powpeg
 cd powpeg && git checkout -f "$POWPEG_NODE_BRANCH"

--- a/container-action/entrypoint.sh
+++ b/container-action/entrypoint.sh
@@ -12,13 +12,12 @@ REPO_OWNER="${INPUT_REPO_OWNER:-rsksmart}"  # Default to 'rsksmart' if not provi
 RSKJ_REPO="${INPUT_RSKJ_REPO:-rskj}"        # Name of the base rskj repo; default to 'rskj'
 GH_TOKEN="${INPUT_GITHUB_TOKEN}"            # Optional; required to clone a private base rskj repo
 
-# Build optional auth for inspecting/cloning a private base rskj repository.
-# When no token is provided, behaviour is identical to the previous public-only flow.
+# Inspect the configured base rskj repository. When a token is provided the
+# request is authenticated so private repos can be checked; otherwise behaviour
+# is identical to the previous public-only flow.
 if [ -n "$GH_TOKEN" ]; then
-  RSKJ_CLONE_AUTH="x-access-token:${GH_TOKEN}@"
   IS_RSKJ_BRANCH=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GH_TOKEN}" "https://api.github.com/repos/$REPO_OWNER/$RSKJ_REPO/branches/$RSKJ_BRANCH")
 else
-  RSKJ_CLONE_AUTH=""
   IS_RSKJ_BRANCH=$(curl -s -o /dev/null -w "%{http_code}" "https://api.github.com/repos/$REPO_OWNER/$RSKJ_REPO/branches/$RSKJ_BRANCH")
 fi
 IS_POWPEG_BRANCH=$(curl -s -o /dev/null -w "%{http_code}" "https://api.github.com/repos/$REPO_OWNER/powpeg-node/branches/$POWPEG_NODE_BRANCH")
@@ -35,10 +34,19 @@ echo -e "\n\n--------- Starting the configuration of rskj ---------\n\n"
 cd /usr/src/
 if [ "$IS_RSKJ_BRANCH" -eq 200 ]; then
   echo "Found matching branch name in $REPO_OWNER/$RSKJ_REPO.git repo"
-  git clone "https://${RSKJ_CLONE_AUTH}github.com/$REPO_OWNER/$RSKJ_REPO.git" rskj
-else
-  echo "Found matching branch name in rsksmart/rskj.git repo"
+  # Pass the token via a per-command HTTP header (with -c) so it is never
+  # embedded in the remote URL nor persisted in rskj/.git/config.
+  if [ -n "$GH_TOKEN" ]; then
+    git -c http.extraheader="AUTHORIZATION: bearer ${GH_TOKEN}" clone "https://github.com/$REPO_OWNER/$RSKJ_REPO.git" rskj
+  else
+    git clone "https://github.com/$REPO_OWNER/$RSKJ_REPO.git" rskj
+  fi
+elif [ "$IS_RSKJ_BRANCH" -eq 404 ]; then
+  echo "No matching branch in $REPO_OWNER/$RSKJ_REPO.git; falling back to default rsksmart/rskj.git repo"
   git clone "https://github.com/rsksmart/rskj.git" rskj
+else
+  echo "Error: unexpected HTTP status $IS_RSKJ_BRANCH while checking $REPO_OWNER/$RSKJ_REPO for branch $RSKJ_BRANCH (check the token permissions or GitHub rate limits)" >&2
+  exit 1
 fi
 cd rskj && git checkout -f "$RSKJ_BRANCH"
 chmod +x ./configure.sh && chmod +x gradlew

--- a/container-action/entrypoint.sh
+++ b/container-action/entrypoint.sh
@@ -20,8 +20,9 @@ GH_TOKEN="${INPUT_GITHUB_TOKEN}"            # Optional; required to clone a priv
 # (e.g. "feature/foo"); Node is already installed in this container.
 #
 # Echoes "found", "notfound" or "error:<http_code>" so callers can keep 404 as
-# the only fallback case and fail fast on auth/rate-limit errors. When a token
-# is set the request is authenticated so private repos can be inspected.
+# the only fallback case and fail fast on any other status (auth, invalid ref,
+# rate limits, ...). When a token is set the request is authenticated so private
+# repos can be inspected.
 ref_status() {
   local owner="$1" repo="$2" ref="$3" ref_enc code
   ref_enc=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$ref")
@@ -32,11 +33,14 @@ ref_status() {
   fi
   if [[ "$code" -eq 200 ]]; then
     echo "found"
-  elif [[ "$code" -eq 404 || "$code" -eq 422 ]]; then
-    # 404: ref not found (or repo not accessible with the given token).
-    # 422: unprocessable ref (e.g. malformed commit sha).
+  elif [[ "$code" -eq 404 ]]; then
+    # 404 is the only "ref not found" case (or repo not accessible with the
+    # given token) and the sole trigger for the upstream fallback.
     echo "notfound"
   else
+    # Everything else (401/403 auth, 422 unprocessable/invalid ref, rate limits,
+    # 5xx, ...) is a hard error so we fail fast instead of silently switching
+    # repos.
     echo "error:$code"
   fi
 }
@@ -84,7 +88,7 @@ elif [[ "$RSKJ_REF_STATUS" == "notfound" ]]; then
     exit 1
   fi
 else
-  echo "Error: unexpected HTTP status ${RSKJ_REF_STATUS#error:} while checking $REPO_OWNER/$RSKJ_REPO for ref $RSKJ_BRANCH (check the token permissions or GitHub rate limits)" >&2
+  echo "Error: unexpected HTTP status ${RSKJ_REF_STATUS#error:} while checking $REPO_OWNER/$RSKJ_REPO for ref $RSKJ_BRANCH (invalid ref, insufficient token permissions, or GitHub rate limits)" >&2
   exit 1
 fi
 cd rskj && git checkout -f "$RSKJ_BRANCH"
@@ -104,7 +108,7 @@ elif [[ "$POWPEG_REF_STATUS" == "notfound" ]]; then
   echo "No ref $POWPEG_NODE_BRANCH in $REPO_OWNER/powpeg-node.git; falling back to default rsksmart/powpeg-node.git repo"
   git clone "https://github.com/rsksmart/powpeg-node.git" powpeg
 else
-  echo "Error: unexpected HTTP status ${POWPEG_REF_STATUS#error:} while checking $REPO_OWNER/powpeg-node for ref $POWPEG_NODE_BRANCH (check the token permissions or GitHub rate limits)" >&2
+  echo "Error: unexpected HTTP status ${POWPEG_REF_STATUS#error:} while checking $REPO_OWNER/powpeg-node for ref $POWPEG_NODE_BRANCH (invalid ref, insufficient token permissions, or GitHub rate limits)" >&2
   exit 1
 fi
 cp configure_gradle_powpeg.sh powpeg

--- a/container-action/entrypoint.sh
+++ b/container-action/entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$IS_RSKJ_BRANCH" -eq 200 ]; then
     git clone "https://github.com/$REPO_OWNER/$RSKJ_REPO.git" rskj
   fi
 elif [ "$IS_RSKJ_BRANCH" -eq 404 ]; then
-  echo "No matching branch in $REPO_OWNER/$RSKJ_REPO.git; falling back to default rsksmart/rskj.git repo"
+  echo "Got HTTP 404 for branch $RSKJ_BRANCH in $REPO_OWNER/$RSKJ_REPO.git (branch not found, or repo not accessible with the provided token); falling back to default rsksmart/rskj.git repo"
   git clone "https://github.com/rsksmart/rskj.git" rskj
 else
   echo "Error: unexpected HTTP status $IS_RSKJ_BRANCH while checking $REPO_OWNER/$RSKJ_REPO for branch $RSKJ_BRANCH (check the token permissions or GitHub rate limits)" >&2
@@ -91,8 +91,13 @@ export LOG_LEVEL="$LOG_LEVEL"
 
 echo -e "\n\n--------- Executing Rootstock Integration Tests ---------\n\n"
 npm install -y
-npm run test-fail-fast
-STATUS=$?
+# Capture the exit code without letting `set -e` abort the script, so the
+# reporting block below always runs and writes status/message to GITHUB_OUTPUT.
+if npm run test-fail-fast; then
+  STATUS=0
+else
+  STATUS=$?
+fi
 
 echo -e "\n\n--------- RIT Tests Result ---------\n\n"
 if [ "$STATUS" -ne 0 ]; then

--- a/container-action/entrypoint.sh
+++ b/container-action/entrypoint.sh
@@ -9,7 +9,18 @@ POWPEG_NODE_BRANCH="${INPUT_POWPEG_NODE_BRANCH}"
 RIT_BRANCH="${INPUT_RIT_BRANCH}"
 LOG_LEVEL="${INPUT_RIT_LOG_LEVEL}"
 REPO_OWNER="${INPUT_REPO_OWNER:-rsksmart}"  # Default to 'rsksmart' if not provided
-IS_RSKJ_BRANCH=$(curl -s -o /dev/null -w "%{http_code}" "https://api.github.com/repos/$REPO_OWNER/rskj/branches/$RSKJ_BRANCH")
+RSKJ_REPO="${INPUT_RSKJ_REPO:-rskj}"        # Name of the base rskj repo; default to 'rskj'
+GH_TOKEN="${INPUT_GITHUB_TOKEN}"            # Optional; required to clone a private base rskj repo
+
+# Build optional auth for inspecting/cloning a private base rskj repository.
+# When no token is provided, behaviour is identical to the previous public-only flow.
+if [ -n "$GH_TOKEN" ]; then
+  RSKJ_CLONE_AUTH="x-access-token:${GH_TOKEN}@"
+  IS_RSKJ_BRANCH=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GH_TOKEN}" "https://api.github.com/repos/$REPO_OWNER/$RSKJ_REPO/branches/$RSKJ_BRANCH")
+else
+  RSKJ_CLONE_AUTH=""
+  IS_RSKJ_BRANCH=$(curl -s -o /dev/null -w "%{http_code}" "https://api.github.com/repos/$REPO_OWNER/$RSKJ_REPO/branches/$RSKJ_BRANCH")
+fi
 IS_POWPEG_BRANCH=$(curl -s -o /dev/null -w "%{http_code}" "https://api.github.com/repos/$REPO_OWNER/powpeg-node/branches/$POWPEG_NODE_BRANCH")
 
 echo -e "\n\n--------- Input parameters received ---------\n\n"
@@ -18,12 +29,13 @@ echo "POWPEG_NODE_BRANCH=$POWPEG_NODE_BRANCH"
 echo "RIT_BRANCH=$RIT_BRANCH"
 echo "LOG_LEVEL=$LOG_LEVEL"
 echo "REPO_OWNER=$REPO_OWNER"
+echo "RSKJ_REPO=$RSKJ_REPO"
 
 echo -e "\n\n--------- Starting the configuration of rskj ---------\n\n"
 cd /usr/src/
-if [[ "$IS_RSKJ_BRANCH" -eq 200 ]]; then
-  echo "Found matching branch name in $REPO_OWNER/rskj.git repo"
-  git clone "https://github.com/$REPO_OWNER/rskj.git" rskj
+if [ "$IS_RSKJ_BRANCH" -eq 200 ]; then
+  echo "Found matching branch name in $REPO_OWNER/$RSKJ_REPO.git repo"
+  git clone "https://${RSKJ_CLONE_AUTH}github.com/$REPO_OWNER/$RSKJ_REPO.git" rskj
 else
   echo "Found matching branch name in rsksmart/rskj.git repo"
   git clone "https://github.com/rsksmart/rskj.git" rskj
@@ -34,7 +46,7 @@ chmod +x ./configure.sh && chmod +x gradlew
 
 echo -e  "\n\n--------- Starting the configuration of powpeg ---------\n\n"
 cd /usr/src/
-if [[ "$IS_POWPEG_BRANCH" -eq 200 ]]; then
+if [ "$IS_POWPEG_BRANCH" -eq 200 ]; then
   echo "Found matching branch name in $REPO_OWNER/powpeg-node.git repo"
   git clone "https://github.com/$REPO_OWNER/powpeg-node.git" powpeg
 else
@@ -75,7 +87,7 @@ npm run test-fail-fast
 STATUS=$?
 
 echo -e "\n\n--------- RIT Tests Result ---------\n\n"
-if [[ $STATUS -ne 0 ]]; then
+if [ "$STATUS" -ne 0 ]; then
   MESSAGE="Rootstock Integration Tests Status: FAILED"
 else
   MESSAGE="Rootstock Integration Tests Status: PASSED"
@@ -85,7 +97,7 @@ echo -e "$MESSAGE"
 echo "status=${STATUS}" >> "${GITHUB_OUTPUT}"
 echo "message=${MESSAGE}" >> "${GITHUB_OUTPUT}"
 
-if [[ $STATUS -ne 0 ]]; then
+if [ "$STATUS" -ne 0 ]; then
   exit 1
 fi
 exit 0

--- a/container-action/entrypoint.sh
+++ b/container-action/entrypoint.sh
@@ -35,9 +35,12 @@ cd /usr/src/
 if [ "$IS_RSKJ_BRANCH" -eq 200 ]; then
   echo "Found matching branch name in $REPO_OWNER/$RSKJ_REPO.git repo"
   # Pass the token via a per-command HTTP header (with -c) so it is never
-  # embedded in the remote URL nor persisted in rskj/.git/config.
+  # embedded in the remote URL nor persisted in rskj/.git/config. GitHub's
+  # git-over-HTTPS endpoint expects Basic auth (base64 of "x-access-token:<token>"),
+  # not a bearer scheme, so build the credential accordingly.
   if [ -n "$GH_TOKEN" ]; then
-    git -c http.extraheader="AUTHORIZATION: bearer ${GH_TOKEN}" clone "https://github.com/$REPO_OWNER/$RSKJ_REPO.git" rskj
+    GH_BASIC_AUTH=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')
+    GIT_TERMINAL_PROMPT=0 git -c http.extraheader="AUTHORIZATION: basic ${GH_BASIC_AUTH}" clone "https://github.com/$REPO_OWNER/$RSKJ_REPO.git" rskj
   else
     git clone "https://github.com/$REPO_OWNER/$RSKJ_REPO.git" rskj
   fi

--- a/container-action/entrypoint.sh
+++ b/container-action/entrypoint.sh
@@ -71,6 +71,7 @@ if [[ "$RSKJ_REF_STATUS" == "found" ]]; then
     # not mask it automatically.
     echo "::add-mask::${GH_BASIC_AUTH}"
     GIT_TERMINAL_PROMPT=0 git -c http.extraheader="Authorization: Basic ${GH_BASIC_AUTH}" clone "https://github.com/$REPO_OWNER/$RSKJ_REPO.git" rskj
+    unset GH_BASIC_AUTH
   else
     git clone "https://github.com/$REPO_OWNER/$RSKJ_REPO.git" rskj
   fi

--- a/container-action/entrypoint.sh
+++ b/container-action/entrypoint.sh
@@ -12,22 +12,37 @@ REPO_OWNER="${INPUT_REPO_OWNER:-rsksmart}"  # Default to 'rsksmart' if not provi
 RSKJ_REPO="${INPUT_RSKJ_REPO:-rskj}"        # Name of the base rskj repo; default to 'rskj'
 GH_TOKEN="${INPUT_GITHUB_TOKEN}"            # Optional; required to clone a private base rskj repo
 
-# URL-encode the branch names before embedding them in the GitHub API path.
-# Branch names can legitimately contain slashes (e.g. "feature/foo"); without
-# encoding, GitHub treats them as extra path segments and returns 404 even when
-# the branch exists. Node is already installed in this container.
-RSKJ_BRANCH_ENC=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$RSKJ_BRANCH")
-POWPEG_NODE_BRANCH_ENC=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$POWPEG_NODE_BRANCH")
+# Resolve whether a git ref exists in a GitHub repository. The inputs may be a
+# branch, a tag or a specific commit (see container-action/README.md), so we use
+# the ref-aware REST "commits/{ref}" endpoint, which resolves all three, instead
+# of "branches/{ref}", which only matches branch names (and would 404 for a
+# valid tag/commit). The ref is URL-encoded because it can contain slashes
+# (e.g. "feature/foo"); Node is already installed in this container.
+#
+# Echoes "found", "notfound" or "error:<http_code>" so callers can keep 404 as
+# the only fallback case and fail fast on auth/rate-limit errors. When a token
+# is set the request is authenticated so private repos can be inspected.
+ref_status() {
+  local owner="$1" repo="$2" ref="$3" ref_enc code
+  ref_enc=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$ref")
+  if [[ -n "$GH_TOKEN" ]]; then
+    code=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GH_TOKEN}" "https://api.github.com/repos/$owner/$repo/commits/$ref_enc")
+  else
+    code=$(curl -s -o /dev/null -w "%{http_code}" "https://api.github.com/repos/$owner/$repo/commits/$ref_enc")
+  fi
+  if [[ "$code" -eq 200 ]]; then
+    echo "found"
+  elif [[ "$code" -eq 404 || "$code" -eq 422 ]]; then
+    # 404: ref not found (or repo not accessible with the given token).
+    # 422: unprocessable ref (e.g. malformed commit sha).
+    echo "notfound"
+  else
+    echo "error:$code"
+  fi
+}
 
-# Inspect the configured base rskj repository. When a token is provided the
-# request is authenticated so private repos can be checked; otherwise behaviour
-# is identical to the previous public-only flow.
-if [[ -n "$GH_TOKEN" ]]; then
-  IS_RSKJ_BRANCH=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GH_TOKEN}" "https://api.github.com/repos/$REPO_OWNER/$RSKJ_REPO/branches/$RSKJ_BRANCH_ENC")
-else
-  IS_RSKJ_BRANCH=$(curl -s -o /dev/null -w "%{http_code}" "https://api.github.com/repos/$REPO_OWNER/$RSKJ_REPO/branches/$RSKJ_BRANCH_ENC")
-fi
-IS_POWPEG_BRANCH=$(curl -s -o /dev/null -w "%{http_code}" "https://api.github.com/repos/$REPO_OWNER/powpeg-node/branches/$POWPEG_NODE_BRANCH_ENC")
+RSKJ_REF_STATUS=$(ref_status "$REPO_OWNER" "$RSKJ_REPO" "$RSKJ_BRANCH")
+POWPEG_REF_STATUS=$(ref_status "$REPO_OWNER" "powpeg-node" "$POWPEG_NODE_BRANCH")
 
 echo -e "\n\n--------- Input parameters received ---------\n\n"
 echo "RSKJ_BRANCH=$RSKJ_BRANCH"
@@ -39,8 +54,8 @@ echo "RSKJ_REPO=$RSKJ_REPO"
 
 echo -e "\n\n--------- Starting the configuration of rskj ---------\n\n"
 cd /usr/src/
-if [[ "$IS_RSKJ_BRANCH" -eq 200 ]]; then
-  echo "Found matching branch name in $REPO_OWNER/$RSKJ_REPO.git repo"
+if [[ "$RSKJ_REF_STATUS" == "found" ]]; then
+  echo "Found matching ref $RSKJ_BRANCH in $REPO_OWNER/$RSKJ_REPO.git repo"
   # Pass the token via a per-command HTTP header (with -c) so it is never
   # embedded in the remote URL nor persisted in rskj/.git/config. GitHub's
   # git-over-HTTPS endpoint expects Basic auth (base64 of "x-access-token:<token>"),
@@ -55,21 +70,21 @@ if [[ "$IS_RSKJ_BRANCH" -eq 200 ]]; then
   else
     git clone "https://github.com/$REPO_OWNER/$RSKJ_REPO.git" rskj
   fi
-elif [[ "$IS_RSKJ_BRANCH" -eq 404 ]]; then
+elif [[ "$RSKJ_REF_STATUS" == "notfound" ]]; then
   # Only fall back to upstream rsksmart/rskj when the caller kept the default
   # base repo name. If a custom rskj-repo was explicitly configured, falling
   # back would silently run the tests against a different codebase than
   # requested (and can mask a missing/insufficient token for a private repo),
   # so treat that as a hard error instead.
   if [[ "$RSKJ_REPO" == "rskj" ]]; then
-    echo "No branch $RSKJ_BRANCH in $REPO_OWNER/$RSKJ_REPO.git (branch not found, or repo not accessible with the provided token); falling back to default rsksmart/rskj.git repo"
+    echo "No ref $RSKJ_BRANCH in $REPO_OWNER/$RSKJ_REPO.git (branch/tag/commit not found, or repo not accessible with the provided token); falling back to default rsksmart/rskj.git repo"
     git clone "https://github.com/rsksmart/rskj.git" rskj
   else
-    echo "Error: branch $RSKJ_BRANCH not found in the explicitly configured $REPO_OWNER/$RSKJ_REPO.git (branch missing, or repo not accessible with the provided token). Refusing to fall back to rsksmart/rskj so the tests are not silently run against a different codebase." >&2
+    echo "Error: ref $RSKJ_BRANCH not found in the explicitly configured $REPO_OWNER/$RSKJ_REPO.git (branch/tag/commit missing, or repo not accessible with the provided token). Refusing to fall back to rsksmart/rskj so the tests are not silently run against a different codebase." >&2
     exit 1
   fi
 else
-  echo "Error: unexpected HTTP status $IS_RSKJ_BRANCH while checking $REPO_OWNER/$RSKJ_REPO for branch $RSKJ_BRANCH (check the token permissions or GitHub rate limits)" >&2
+  echo "Error: unexpected HTTP status ${RSKJ_REF_STATUS#error:} while checking $REPO_OWNER/$RSKJ_REPO for ref $RSKJ_BRANCH (check the token permissions or GitHub rate limits)" >&2
   exit 1
 fi
 cd rskj && git checkout -f "$RSKJ_BRANCH"
@@ -78,17 +93,18 @@ chmod +x ./configure.sh && chmod +x gradlew
 
 echo -e  "\n\n--------- Starting the configuration of powpeg ---------\n\n"
 cd /usr/src/
-if [[ "$IS_POWPEG_BRANCH" -eq 200 ]]; then
-  echo "Found matching branch name in $REPO_OWNER/powpeg-node.git repo"
+if [[ "$POWPEG_REF_STATUS" == "found" ]]; then
+  echo "Found matching ref $POWPEG_NODE_BRANCH in $REPO_OWNER/powpeg-node.git repo"
   git clone "https://github.com/$REPO_OWNER/powpeg-node.git" powpeg
-elif [[ "$IS_POWPEG_BRANCH" -eq 404 ]]; then
-  # Only a genuine 404 (branch not found in the configured owner) triggers the
-  # fallback to upstream rsksmart/powpeg-node. Any other status (401/403/rate
-  # limit) is treated as a hard error so we never silently switch repos.
-  echo "No branch $POWPEG_NODE_BRANCH in $REPO_OWNER/powpeg-node.git; falling back to default rsksmart/powpeg-node.git repo"
+elif [[ "$POWPEG_REF_STATUS" == "notfound" ]]; then
+  # Only a genuine not-found (branch/tag/commit absent in the configured owner)
+  # triggers the fallback to upstream rsksmart/powpeg-node. Any other status
+  # (401/403/rate limit) is treated as a hard error so we never silently switch
+  # repos.
+  echo "No ref $POWPEG_NODE_BRANCH in $REPO_OWNER/powpeg-node.git; falling back to default rsksmart/powpeg-node.git repo"
   git clone "https://github.com/rsksmart/powpeg-node.git" powpeg
 else
-  echo "Error: unexpected HTTP status $IS_POWPEG_BRANCH while checking $REPO_OWNER/powpeg-node for branch $POWPEG_NODE_BRANCH (check the token permissions or GitHub rate limits)" >&2
+  echo "Error: unexpected HTTP status ${POWPEG_REF_STATUS#error:} while checking $REPO_OWNER/powpeg-node for ref $POWPEG_NODE_BRANCH (check the token permissions or GitHub rate limits)" >&2
   exit 1
 fi
 cp configure_gradle_powpeg.sh powpeg

--- a/container-action/entrypoint.sh
+++ b/container-action/entrypoint.sh
@@ -45,8 +45,18 @@ if [ "$IS_RSKJ_BRANCH" -eq 200 ]; then
     git clone "https://github.com/$REPO_OWNER/$RSKJ_REPO.git" rskj
   fi
 elif [ "$IS_RSKJ_BRANCH" -eq 404 ]; then
-  echo "Got HTTP 404 for branch $RSKJ_BRANCH in $REPO_OWNER/$RSKJ_REPO.git (branch not found, or repo not accessible with the provided token); falling back to default rsksmart/rskj.git repo"
-  git clone "https://github.com/rsksmart/rskj.git" rskj
+  # Only fall back to upstream rsksmart/rskj when the caller kept the default
+  # base repo name. If a custom rskj-repo was explicitly configured, falling
+  # back would silently run the tests against a different codebase than
+  # requested (and can mask a missing/insufficient token for a private repo),
+  # so treat that as a hard error instead.
+  if [ "$RSKJ_REPO" = "rskj" ]; then
+    echo "No branch $RSKJ_BRANCH in $REPO_OWNER/$RSKJ_REPO.git (branch not found, or repo not accessible with the provided token); falling back to default rsksmart/rskj.git repo"
+    git clone "https://github.com/rsksmart/rskj.git" rskj
+  else
+    echo "Error: branch $RSKJ_BRANCH not found in the explicitly configured $REPO_OWNER/$RSKJ_REPO.git (branch missing, or repo not accessible with the provided token). Refusing to fall back to rsksmart/rskj so the tests are not silently run against a different codebase." >&2
+    exit 1
+  fi
 else
   echo "Error: unexpected HTTP status $IS_RSKJ_BRANCH while checking $REPO_OWNER/$RSKJ_REPO for branch $RSKJ_BRANCH (check the token permissions or GitHub rate limits)" >&2
   exit 1

--- a/container-action/entrypoint.sh
+++ b/container-action/entrypoint.sh
@@ -12,15 +12,22 @@ REPO_OWNER="${INPUT_REPO_OWNER:-rsksmart}"  # Default to 'rsksmart' if not provi
 RSKJ_REPO="${INPUT_RSKJ_REPO:-rskj}"        # Name of the base rskj repo; default to 'rskj'
 GH_TOKEN="${INPUT_GITHUB_TOKEN}"            # Optional; required to clone a private base rskj repo
 
+# URL-encode the branch names before embedding them in the GitHub API path.
+# Branch names can legitimately contain slashes (e.g. "feature/foo"); without
+# encoding, GitHub treats them as extra path segments and returns 404 even when
+# the branch exists. Node is already installed in this container.
+RSKJ_BRANCH_ENC=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$RSKJ_BRANCH")
+POWPEG_NODE_BRANCH_ENC=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$POWPEG_NODE_BRANCH")
+
 # Inspect the configured base rskj repository. When a token is provided the
 # request is authenticated so private repos can be checked; otherwise behaviour
 # is identical to the previous public-only flow.
-if [ -n "$GH_TOKEN" ]; then
-  IS_RSKJ_BRANCH=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GH_TOKEN}" "https://api.github.com/repos/$REPO_OWNER/$RSKJ_REPO/branches/$RSKJ_BRANCH")
+if [[ -n "$GH_TOKEN" ]]; then
+  IS_RSKJ_BRANCH=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GH_TOKEN}" "https://api.github.com/repos/$REPO_OWNER/$RSKJ_REPO/branches/$RSKJ_BRANCH_ENC")
 else
-  IS_RSKJ_BRANCH=$(curl -s -o /dev/null -w "%{http_code}" "https://api.github.com/repos/$REPO_OWNER/$RSKJ_REPO/branches/$RSKJ_BRANCH")
+  IS_RSKJ_BRANCH=$(curl -s -o /dev/null -w "%{http_code}" "https://api.github.com/repos/$REPO_OWNER/$RSKJ_REPO/branches/$RSKJ_BRANCH_ENC")
 fi
-IS_POWPEG_BRANCH=$(curl -s -o /dev/null -w "%{http_code}" "https://api.github.com/repos/$REPO_OWNER/powpeg-node/branches/$POWPEG_NODE_BRANCH")
+IS_POWPEG_BRANCH=$(curl -s -o /dev/null -w "%{http_code}" "https://api.github.com/repos/$REPO_OWNER/powpeg-node/branches/$POWPEG_NODE_BRANCH_ENC")
 
 echo -e "\n\n--------- Input parameters received ---------\n\n"
 echo "RSKJ_BRANCH=$RSKJ_BRANCH"
@@ -32,25 +39,29 @@ echo "RSKJ_REPO=$RSKJ_REPO"
 
 echo -e "\n\n--------- Starting the configuration of rskj ---------\n\n"
 cd /usr/src/
-if [ "$IS_RSKJ_BRANCH" -eq 200 ]; then
+if [[ "$IS_RSKJ_BRANCH" -eq 200 ]]; then
   echo "Found matching branch name in $REPO_OWNER/$RSKJ_REPO.git repo"
   # Pass the token via a per-command HTTP header (with -c) so it is never
   # embedded in the remote URL nor persisted in rskj/.git/config. GitHub's
   # git-over-HTTPS endpoint expects Basic auth (base64 of "x-access-token:<token>"),
   # not a bearer scheme, so build the credential accordingly.
-  if [ -n "$GH_TOKEN" ]; then
+  if [[ -n "$GH_TOKEN" ]]; then
     GH_BASIC_AUTH=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')
-    GIT_TERMINAL_PROMPT=0 git -c http.extraheader="AUTHORIZATION: basic ${GH_BASIC_AUTH}" clone "https://github.com/$REPO_OWNER/$RSKJ_REPO.git" rskj
+    # Mask the derived credential so it is not printed in logs (e.g. under
+    # GIT_TRACE_CURL=1); it differs from the original secret so Actions would
+    # not mask it automatically.
+    echo "::add-mask::${GH_BASIC_AUTH}"
+    GIT_TERMINAL_PROMPT=0 git -c http.extraheader="Authorization: Basic ${GH_BASIC_AUTH}" clone "https://github.com/$REPO_OWNER/$RSKJ_REPO.git" rskj
   else
     git clone "https://github.com/$REPO_OWNER/$RSKJ_REPO.git" rskj
   fi
-elif [ "$IS_RSKJ_BRANCH" -eq 404 ]; then
+elif [[ "$IS_RSKJ_BRANCH" -eq 404 ]]; then
   # Only fall back to upstream rsksmart/rskj when the caller kept the default
   # base repo name. If a custom rskj-repo was explicitly configured, falling
   # back would silently run the tests against a different codebase than
   # requested (and can mask a missing/insufficient token for a private repo),
   # so treat that as a hard error instead.
-  if [ "$RSKJ_REPO" = "rskj" ]; then
+  if [[ "$RSKJ_REPO" == "rskj" ]]; then
     echo "No branch $RSKJ_BRANCH in $REPO_OWNER/$RSKJ_REPO.git (branch not found, or repo not accessible with the provided token); falling back to default rsksmart/rskj.git repo"
     git clone "https://github.com/rsksmart/rskj.git" rskj
   else
@@ -67,7 +78,7 @@ chmod +x ./configure.sh && chmod +x gradlew
 
 echo -e  "\n\n--------- Starting the configuration of powpeg ---------\n\n"
 cd /usr/src/
-if [ "$IS_POWPEG_BRANCH" -eq 200 ]; then
+if [[ "$IS_POWPEG_BRANCH" -eq 200 ]]; then
   echo "Found matching branch name in $REPO_OWNER/powpeg-node.git repo"
   git clone "https://github.com/$REPO_OWNER/powpeg-node.git" powpeg
 else
@@ -113,7 +124,7 @@ else
 fi
 
 echo -e "\n\n--------- RIT Tests Result ---------\n\n"
-if [ "$STATUS" -ne 0 ]; then
+if [[ "$STATUS" -ne 0 ]]; then
   MESSAGE="Rootstock Integration Tests Status: FAILED"
 else
   MESSAGE="Rootstock Integration Tests Status: PASSED"
@@ -123,7 +134,7 @@ echo -e "$MESSAGE"
 echo "status=${STATUS}" >> "${GITHUB_OUTPUT}"
 echo "message=${MESSAGE}" >> "${GITHUB_OUTPUT}"
 
-if [ "$STATUS" -ne 0 ]; then
+if [[ "$STATUS" -ne 0 ]]; then
   exit 1
 fi
 exit 0


### PR DESCRIPTION
In order to be able to run RIT from forks, we should let the rskj repo configurable. This will facilitate perform security validations that need to be done on private repos.

The repo that is fetching RIT need an access token to fetch it, we still control this.