### PR TITLE
Ensure SVP spend tx is registered

### DIFF
--- a/lib/rsk-utils.js
+++ b/lib/rsk-utils.js
@@ -251,9 +251,6 @@ const waitForRskMempoolToGetThisCountOfThisTxType = async (
     onEachAttempt = null
 ) => {
     const method = async () => {
-        if (onEachAttempt) {
-            await onEachAttempt();
-        }
         const mempoolTxs = await getRskMempoolTransactionsToTheBridge(rskTxHelper, true);
         const txsToBridge = mempoolTxs.filter((tx) => tx.input?.startsWith(txType.methodSelector));
 
@@ -266,6 +263,11 @@ const waitForRskMempoolToGetThisCountOfThisTxType = async (
         logger.debug(
             `[${waitForRskMempoolToGetThisCountOfThisTxType.name}] Found ${txsToBridge.length} ${txType.name} txs in the rsk mempool, expected at least ${expectedCount}. Will keep retrying until it is found or it reaches the max attempts to find it`
         );
+        // Only retrigger when the expected txs are not in the mempool yet, so an already-satisfied
+        // wait does not cause an unnecessary extra submission.
+        if (onEachAttempt) {
+            await onEachAttempt();
+        }
         return false;
     };
 

--- a/lib/rsk-utils.js
+++ b/lib/rsk-utils.js
@@ -247,9 +247,13 @@ const waitForRskMempoolToGetThisCountOfThisTxType = async (
     txType,
     expectedCount,
     maxAttempts = 24,
-    checkEveryMilliseconds = 2000
+    checkEveryMilliseconds = 2000,
+    onEachAttempt = null
 ) => {
     const method = async () => {
+        if (onEachAttempt) {
+            await onEachAttempt();
+        }
         const mempoolTxs = await getRskMempoolTransactionsToTheBridge(rskTxHelper, true);
         const txsToBridge = mempoolTxs.filter((tx) => tx.input?.startsWith(txType.methodSelector));
 
@@ -279,14 +283,16 @@ const waitForRskMempoolToGetThisCountOfRegisterBtcTx = async (
     rskTxHelper,
     expectedCount,
     maxAttempts = 24,
-    checkEveryMilliseconds = 2000
+    checkEveryMilliseconds = 2000,
+    onEachAttempt = null
 ) => {
     return waitForRskMempoolToGetThisCountOfThisTxType(
         rskTxHelper,
         BRIDGE_TX_TYPES.REGISTER_BTC_TRANSACTION,
         expectedCount,
         maxAttempts,
-        checkEveryMilliseconds
+        checkEveryMilliseconds,
+        onEachAttempt
     );
 };
 

--- a/lib/tests/change-federation.js
+++ b/lib/tests/change-federation.js
@@ -924,16 +924,24 @@ const execute = (description, newFederationConfig) => {
             await waitForBitcoinTxToBeInMempool(btcTxHelper, svpSpendBtcTransaction.getId());
             await btcTxHelper.mine(BTC_TO_RSK_MINIMUM_CONFIRMATIONS);
 
-            // Even though a proposed federator cannot call `updateCollections`, inside the powpeg `updateBridge` there are 4 calls to the Bridge.
-            // One of them is `registerBtcTransaction`. The last one is `updateCollections`. Since the active federation's federators don't recognize the spend svp tx
-            // as a valid btc tx to send to the Bridge, they will not send it. But the proposed federation's federators will send it.
-            // This is why we are calling that `updateBridge` method with a proposed federator, so `registerBtcTransaction` gets called, and then we can call `updateCollections` latest with an active federation's federator.
-            const proposedFedRskTxHelper = rskTxHelpers[rskTxHelpers.length - 1];
+            // The SVP spend tx pays the active federation, so it is an ACTIVE federation federator whose btc
+            // wallet sees it and who sends `registerBtcTransaction` for it (the powpeg matches it in
+            // `shouldSendTx` via `isSVPSpendTx`). Proposed federation members cannot do it: they only run a
+            // `BtcReleaseClient` for signing the svp spend tx, but no `BtcToRskClient` watching any federation
+            // wallet, so `updateBridge` on them never produces a `registerBtcTransaction`.
+            const svpSpendTxAlreadyRegistered = await bridge.methods
+                .isBtcTxHashAlreadyProcessed(svpSpendBtcTransaction.getId())
+                .call();
 
-            // Retrigger the proposed federator's `updateBridge` on every attempt until its `registerBtcTransaction` call lands in the mempool. 
-            await rskUtils.waitForRskMempoolToGetThisCountOfRegisterBtcTx(rskTxHelper, 1, 24, 2000, () =>
-                proposedFedRskTxHelper.updateBridge()
-            );
+            if (!svpSpendTxAlreadyRegistered) {
+                // The federator only sends the register tx once its own btc peer has seen the just-mined
+                // blocks, which under load can lag well past any fixed wait, and since RIT disables the
+                // powpeg's `updateBridge` timer, no one retries on its behalf: retrigger `updateBridge` on
+                // every attempt until the register tx lands in the mempool.
+                await rskUtils.waitForRskMempoolToGetThisCountOfRegisterBtcTx(rskTxHelper, 1, 24, 2000, () =>
+                    rskTxHelper.updateBridge()
+                );
+            }
 
             // Now calling `updateCollections` with a federator from the active federation to really call `updateCollections`.
             await rskUtils.waitAndUpdateBridge(rskTxHelper);

--- a/lib/tests/change-federation.js
+++ b/lib/tests/change-federation.js
@@ -929,22 +929,23 @@ const execute = (description, newFederationConfig) => {
             // `shouldSendTx` via `isSVPSpendTx`). Proposed federation members cannot do it: they only run a
             // `BtcReleaseClient` for signing the svp spend tx, but no `BtcToRskClient` watching any federation
             // wallet, so `updateBridge` on them never produces a `registerBtcTransaction`.
-            const svpSpendTxAlreadyRegistered = await bridge.methods
-                .isBtcTxHashAlreadyProcessed(svpSpendBtcTransaction.getId())
-                .call();
-
-            if (!svpSpendTxAlreadyRegistered) {
-                // The federator only sends the register tx once its own btc peer has seen the just-mined
-                // blocks, which under load can lag well past any fixed wait, and since RIT disables the
-                // powpeg's `updateBridge` timer, no one retries on its behalf: retrigger `updateBridge` on
-                // every attempt until the register tx lands in the mempool.
-                await rskUtils.waitForRskMempoolToGetThisCountOfRegisterBtcTx(rskTxHelper, 1, 24, 2000, () =>
-                    rskTxHelper.updateBridge()
-                );
+            //
+            // Registering a segwit tx takes at least 3 updateBridge + mine cycles, because each step is
+            // gated on the previous one being MINED in the Bridge:
+            //   1. `receiveHeaders` informs the btc block containing the tx,
+            //   2. only once the block is informed does the federator send `registerBtcCoinbaseTransaction`
+            //      (the Bridge needs the coinbase's witness commitment to validate a wtxid-based pmt),
+            //   3. only once the coinbase is registered does the re-sent `registerBtcTransaction` pass
+            //      validation — until then the Bridge rejects it with "Could not validate transaction".
+            // So keep driving updateBridge + mine cycles until the Bridge reports the tx processed.
+            const maxRegistrationCycles = 10;
+            let svpSpendTxRegistered = false;
+            for (let cycle = 0; cycle < maxRegistrationCycles && !svpSpendTxRegistered; cycle++) {
+                await rskUtils.waitAndUpdateBridge(rskTxHelper);
+                svpSpendTxRegistered = await bridge.methods
+                    .isBtcTxHashAlreadyProcessed(svpSpendBtcTransaction.getId())
+                    .call();
             }
-
-            // Now calling `updateCollections` with a federator from the active federation to really call `updateCollections`.
-            await rskUtils.waitAndUpdateBridge(rskTxHelper);
 
             const destinationAddress = bitcoinJsLib.address.fromOutputScript(
                 svpSpendBtcTransaction.outs[0].script,
@@ -955,9 +956,6 @@ const execute = (description, newFederationConfig) => {
                 'The destination address in the SVP Spend transaction should be the active federation address.'
             );
 
-            const svpSpendTxRegistered = await bridge.methods
-                .isBtcTxHashAlreadyProcessed(svpSpendBtcTransaction.getId())
-                .call();
             expect(
                 svpSpendTxRegistered,
                 'The SVP Spend transaction should be registered in the Bridge by now.'

--- a/lib/tests/change-federation.js
+++ b/lib/tests/change-federation.js
@@ -929,14 +929,11 @@ const execute = (description, newFederationConfig) => {
             // as a valid btc tx to send to the Bridge, they will not send it. But the proposed federation's federators will send it.
             // This is why we are calling that `updateBridge` method with a proposed federator, so `registerBtcTransaction` gets called, and then we can call `updateCollections` latest with an active federation's federator.
             const proposedFedRskTxHelper = rskTxHelpers[rskTxHelpers.length - 1];
-            const shouldMineAndSync = false; // We will mine and sync in the next `waitAndUpdateBridge` call.
-            await rskUtils.waitAndUpdateBridge(proposedFedRskTxHelper, 1000, shouldMineAndSync);
-            await rskUtils.waitAndUpdateBridge(proposedFedRskTxHelper, 1000, shouldMineAndSync);
 
-            // Wait until the proposed federator's `registerBtcTransaction` call actually lands in the mempool
-            // instead of assuming the fixed waits above were enough. The federator node reads the just-mined
-            // btc confirmations from its own poll loop, and under load that can lag past 2 seconds.
-            await rskUtils.waitForRskMempoolToGetThisCountOfRegisterBtcTx(rskTxHelper, 1);
+            // Retrigger the proposed federator's `updateBridge` on every attempt until its `registerBtcTransaction` call lands in the mempool. 
+            await rskUtils.waitForRskMempoolToGetThisCountOfRegisterBtcTx(rskTxHelper, 1, 24, 2000, () =>
+                proposedFedRskTxHelper.updateBridge()
+            );
 
             // Now calling `updateCollections` with a federator from the active federation to really call `updateCollections`.
             await rskUtils.waitAndUpdateBridge(rskTxHelper);


### PR DESCRIPTION
This pull request refactors the logic for waiting on RSK mempool transactions and improves the reliability of the federation change test. The main changes include making the wait functions more flexible by adding an optional callback, and updating the test to use a more robust polling loop for SVP spend transaction registration instead of fixed waits.

**Enhancements to wait functions:**

* Added an optional `onEachAttempt` callback parameter to `waitForRskMempoolToGetThisCountOfThisTxType` and `waitForRskMempoolToGetThisCountOfRegisterBtcTx`, allowing custom logic to be executed on each polling attempt. [[1]](diffhunk://#diff-5ae6cb268232abc556725fd7b7c48ea39c206a51ca4ca4c3b4e122fbe24c741aL250-R251) [[2]](diffhunk://#diff-5ae6cb268232abc556725fd7b7c48ea39c206a51ca4ca4c3b4e122fbe24c741aL282-R297)
* Updated the polling logic to call `onEachAttempt` only when the expected transactions are not yet in the mempool, preventing unnecessary extra submissions.

**Improvements to federation change test reliability:**

* Replaced the previous fixed-wait approach with a polling loop in `lib/tests/change-federation.js` that repeatedly calls `waitAndUpdateBridge` and checks for SVP spend transaction registration, making the test more robust to timing variations.
* Removed redundant code that checked SVP spend transaction registration after the loop, since it is now handled within the polling loop.