### PR TITLE
[P0-01] Emit a JUnit test report artifact and feed the monitoring & reporting tool

### DIFF
--- a/.claude/qa-profile.json
+++ b/.claude/qa-profile.json
@@ -1,0 +1,62 @@
+{
+  "product": "rootstock-integration-tests",
+  "layer": "qa-blockchain",
+  "layers": [
+    "qa-blockchain"
+  ],
+  "environments": [
+    "regtest"
+  ],
+  "dimensions": {
+    "suite": [
+      "smoke",
+      "regression"
+    ],
+    "network": [
+      "regtest"
+    ]
+  },
+  "tagMatrix": {
+    "required": [
+      "suite",
+      "env"
+    ]
+  },
+  "blockchain": {
+    "runner": "mocha",
+    "scopes": [
+      "node-rpc-testing",
+      "onchain-validation",
+      "chain-infra",
+      "differential-compatibility"
+    ],
+    "buildsOn": []
+  },
+  "grid": {
+    "provider": "none"
+  },
+  "reporting": {
+    "adapter": "rootiematio",
+    "config": {
+      "repo": "rsksmart/rootstock-integration-tests",
+      "artifact": "junit-xml"
+    },
+    "_note": "mocha-multi-reporters keeps human-readable spec output AND writes JUnit XML to reports/junit.xml (gitignored *.xml). The ci.yml test-container-action job uploads it via actions/upload-artifact as a single artifact named 'rit-junit-report' on every trigger (PR and push to main). Rootiematio is outbound-only: it polls GHA and ingests the JUnit XML artifact — no in-suite SDK/token. Confirm the 'rit-junit-report' artifact name maps on the Rootiematio project side."
+  },
+  "ci": {
+    "host": "github-actions"
+  },
+  "loops": {
+    "nightly-triage": {
+      "enabled": false,
+      "cadence": "0 6 * * *",
+      "draftCap": 6
+    }
+  },
+  "configPointers": {
+    "baseUrls": "N/A — spins up a local rskj powpeg-node + bitcoind in regtest; node/JAR/bitcoind paths come from .env (see .env-example) and config/.",
+    "secrets": ".env (gitignored); .env-example is the template."
+  },
+  "_overlay": "qa-rootstock",
+  "_knowledge": "qa-rootstock/knowledge/ (RSK domain facts: bridge, json-rpc-catalog, regtest-accounts, differential-testing, rskj-node)."
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,15 +150,26 @@ jobs:
           INPUT_RIT_BRANCH: ${{ env.RIT_BRANCH }}
           INPUT_RIT_LOG_LEVEL: info
         run: |
+          mkdir -p "${{ github.workspace }}/reports"
           docker run \
             --env GITHUB_OUTPUT="/github-output"  \
+            --env GITHUB_WORKSPACE="/github/workspace"  \
             --env INPUT_RSKJ_BRANCH="${{ env.RSKJ_BRANCH }}"  \
             --env INPUT_POWPEG_NODE_BRANCH="${{ env.POWPEG_BRANCH }}"  \
             --env INPUT_RIT_BRANCH="${{ env.RIT_BRANCH }}"  \
             --env INPUT_RIT_LOG_LEVEL="${{ env.INPUT_RIT_LOG_LEVEL }}" \
             --env INPUT_TEST_SUITE="${{ env.TEST_SUITE }}" \
             -v "$GITHUB_OUTPUT:/github-output"  \
+            -v "${{ github.workspace }}/reports:/github/workspace/reports"  \
             --rm ${{ env.TEST_TAG }}
+
+      - name: Upload JUnit report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: rit-junit-report
+          path: reports/junit.xml
+          if-no-files-found: warn
 
       - name: Check Slack Token
         id: check-slack-token
@@ -282,7 +293,6 @@ jobs:
           install: true
           driver-opts: network=host
           platforms: linux/amd64
-
       - name: GitHub container registry login
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,4 @@
+{
+  "reporter": "mocha-multi-reporters",
+  "reporter-option": ["configFile=config/reporters.json"]
+}

--- a/config/reporters.json
+++ b/config/reporters.json
@@ -1,0 +1,9 @@
+{
+  "reporterEnabled": "spec, mocha-junit-reporter",
+  "mochaJunitReporterReporterOptions": {
+    "mochaFile": "reports/junit.xml",
+    "includePending": true,
+    "outputs": true,
+    "toConsole": false
+  }
+}

--- a/container-action/entrypoint.sh
+++ b/container-action/entrypoint.sh
@@ -144,6 +144,26 @@ chmod +x ./configure_rit_locally.sh
 
 export LOG_LEVEL="$LOG_LEVEL"
 
+# --- P0-01: preserve the JUnit report for CI artifact upload (on pass or fail) ---
+# The suite writes reports/junit.xml inside this container. GITHUB_WORKSPACE is the
+# runner-host path mounted in by the container action (and by the docker-run CI job).
+# Copying the report there on EXIT lets actions/upload-artifact collect it on every
+# exit path, including the `exit 1` taken when the test run fails below.
+copy_junit_report() {
+  local report="/usr/src/rit/reports/junit.xml"
+  local dest="${GITHUB_WORKSPACE:-}/reports"
+  # Nothing to do when not running under Actions or the suite produced no report.
+  [ -n "${GITHUB_WORKSPACE:-}" ] && [ -f "$report" ] || return 0
+  # Guard the copy in a conditional so a failure neither aborts the trap under
+  # `set -e` nor gets reported as a success.
+  if mkdir -p "$dest" && cp "$report" "$dest/junit.xml"; then
+    echo "Copied JUnit report to $dest/junit.xml"
+  else
+    echo "Warning: could not copy JUnit report to $dest/junit.xml" >&2
+  fi
+}
+trap copy_junit_report EXIT
+
 echo -e "\n\n--------- Executing Rootstock Integration Tests ($TEST_SUITE suite) ---------\n\n"
 npm install -y
 if [[ "$TEST_SUITE" == "short" ]]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "log4js": "6.9.1",
         "mocha": "10.8.2",
         "mocha-junit-reporter": "2.2.1",
+        "mocha-multi-reporters": "1.5.1",
         "pegin-address-verificator": "git+https://git@github.com/rsksmart/pegin-address-verifier#v0.4.0",
         "peglib": "git+https://github.com/rsksmart/rsk-peglib#v1.4.15",
         "rsk-transaction-helper": "git+https://github.com/rsksmart/rootstock-transaction-helper#v3.1.0",
@@ -4924,6 +4925,22 @@
       },
       "peerDependencies": {
         "mocha": ">=2.2.5"
+      }
+    },
+    "node_modules/mocha-multi-reporters": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/mocha-multi-reporters/-/mocha-multi-reporters-1.5.1.tgz",
+      "integrity": "sha512-Yb4QJOaGLIcmB0VY7Wif5AjvLMUFAdV57D2TWEva1Y0kU/3LjKpeRVmlMIfuO1SVbauve459kgtIizADqxMWPg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "lodash": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "mocha": ">=3.1.2"
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "log4js": "6.9.1",
     "mocha": "10.8.2",
     "mocha-junit-reporter": "2.2.1",
+    "mocha-multi-reporters": "1.5.1",
     "pegin-address-verificator": "git+https://git@github.com/rsksmart/pegin-address-verifier#v0.4.0",
     "peglib": "git+https://github.com/rsksmart/rsk-peglib#v1.4.15",
     "rsk-transaction-helper": "git+https://github.com/rsksmart/rootstock-transaction-helper#v3.1.0",


### PR DESCRIPTION
This pull request introduces a robust JUnit reporting workflow for integration tests, ensuring that test results are consistently generated, preserved, and uploaded as CI artifacts for further analysis and reporting. The changes span configuration, CI workflow, and dependency updates to support multi-reporter output and artifact handling.

**JUnit Reporting Integration**

* Added `.mocharc.json` and `config/reporters.json` to configure `mocha-multi-reporters` for simultaneous human-readable and JUnit XML output, with the XML written to `reports/junit.xml`. [[1]](diffhunk://#diff-b7d0d398a11cbd2cc0b7a66a92cf393712fc0e54fd85f7dac46efa6b82348722R1-R5) [[2]](diffhunk://#diff-b836d07ab9b1d6042569720b4003c155f41f861509a297fc3337952599852912R1-R9)
* Updated `package.json` to include the `mocha-multi-reporters` dependency required for multi-format reporting.

**CI Workflow Enhancements**

* Modified `.github/workflows/ci.yml` to:
  * Mount the `reports` directory into the test container and ensure it exists before test execution.
  * Add a dedicated step to upload `reports/junit.xml` as the `rit-junit-report` artifact, regardless of test outcome.
* Updated `container-action/entrypoint.sh` to trap exit and copy the JUnit report from the container to the mounted workspace, ensuring the report is available for artifact upload even on failure.

**QA Profile and Documentation**

* Added `.claude/qa-profile.json` to document the QA layer, test dimensions, reporting adapter, and artifact mapping, providing context on how JUnit XML is produced and ingested by reporting tools.

These changes collectively ensure reliable generation, preservation, and reporting of integration test results in CI.