### PR TITLE
[P0-02] Interim test classification via Mocha --grep tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,38 @@ This is controlled by the `TEST_SUITE` environment variable (`short` or `full`, 
 
 Pull requests are automatically escalated to the `full` suite when they modify files that only the full run exercises end-to-end: anything under a `tests/**/extra/` folder, the shared test-body and assertion modules (`lib/tests/`, `lib/assertions/`), or the suite machinery itself (`test.js`, `config/`). To override the suite selection explicitly, add a `` `test-suite:full` `` or `` `test-suite:short` `` tag to the PR description — an explicit tag always wins over the automatic escalation.
 
+### Running tests by tag (smoke / regression / behaviour area)
+
+Tests are also classified with tags embedded in their `describe`/`it` titles, so you can select a scope with Mocha's native [`--grep`](https://mochajs.org/#-grep-regexp-g-regexp) — no new dependency. `--grep` matches against the full test title, so a tag on a file's top-level `describe` applies to every test in that file.
+
+Tag vocabulary:
+
+| Tag | Selects |
+| --- | --- |
+| `@smoke` | Fast, high-signal subset for quick feedback (currently the foundational `00_sync` → federation change → core `2wp` flow). |
+| `@regression` | The full relevant set (every tagged test). |
+| `@sync` | Federator sync. |
+| `@federation-change` | Federation change flows and powpeg redeem script. |
+| `@2wp` / `@pegin` / `@pegout` | Two-way-peg tests (peg-in / peg-out). |
+| `@flyover` | Flyover / fast-bridge tests. |
+| `@union-bridge` | Union Bridge functionality. |
+| `@fork-activation` | Tests exercising fork-activated behaviour. |
+| `@bridge-methods` | Bridge JSON-RPC / precompile / governance-voting method tests. |
+
+Convenience scripts:
+
+- `npm run test:smoke` — runs the `@smoke` subset (`mocha --grep @smoke`).
+- `npm run test:regression` — runs the `@regression` set (`mocha --grep @regression`), equivalent to the full suite.
+
+Run any other tag (or combination) by passing `--grep` through `npm test`:
+
+```
+npm test -- --grep @flyover
+npm test -- --grep "@2wp"
+```
+
+> Note: tests share blockchain state and must run in folder order (see above). A `--grep` scope only runs green if the selected tests form a runnable prefix — `@smoke` is curated to satisfy this. Arbitrary single-area greps (e.g. `@flyover` alone) may fail on missing prerequisite state until per-test isolation lands.
+
 ## Running the tests with a different configuration file
 
 1. Create a configuration file, e.g., `config/another_config.js`.

--- a/README.md
+++ b/README.md
@@ -136,9 +136,8 @@ Tag vocabulary:
 | `@federation-change` | Federation change flows and powpeg redeem script. |
 | `@2wp` / `@pegin` / `@pegout` | Two-way-peg tests (peg-in / peg-out). |
 | `@flyover` | Flyover / fast-bridge tests. |
-| `@union-bridge` | Union Bridge functionality. |
-| `@fork-activation` | Tests exercising fork-activated behaviour. |
 | `@bridge-methods` | Bridge JSON-RPC / precompile / governance-voting method tests. |
+| `@precompiled` | Tests targeting RSK native/precompiled contracts (e.g. BlockHeader precompile). |
 
 Convenience scripts:
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "test-short-fail-fast": "TEST_SUITE=short mocha -b --timeout 1200000 --trace-warnings",
     "test-long": "npm run test",
     "test-long-fail-fast": "npm run test-fail-fast",
+    "test:smoke": "TEST_SUITE=short mocha --grep @smoke --timeout 1200000",
+    "test:regression": "TEST_SUITE=full mocha --grep @regression --timeout 1200000",
     "run-tests-multiple-times": "node multipleTestExecutionsRunner.js",
     "run-single-test-file": "node singleTestFileRunner.js",
     "run-with-docker": "node runWithDocker.js",

--- a/tests/00_sync/01-sync.js
+++ b/tests/00_sync/01-sync.js
@@ -6,7 +6,7 @@ const { getRskTransactionHelpers } = require('../../lib/rsk-tx-helper-provider')
 
 const WAIT_IN_MILLISECONDS = 5000;
 
-describe('Federators sync', () => {
+describe('@smoke @regression @sync Federators sync', () => {
     it('should sync all rsk federator nodes when one of them manually mines', async () => {
         try {
             await wait(WAIT_IN_MILLISECONDS);

--- a/tests/01_powpeg/01-change-federation.js
+++ b/tests/01_powpeg/01-change-federation.js
@@ -1,6 +1,6 @@
 const federationChangeTests = require('../../lib/tests/change-federation');
 
 federationChangeTests.executeShort(
-    'Initial Federation change from genesis to p2wsh',
+    '@smoke @regression @federation-change Initial Federation change from genesis to p2wsh',
     Runners.config.federations.secondFederation
 );

--- a/tests/01_powpeg/02-2wp.js
+++ b/tests/01_powpeg/02-2wp.js
@@ -1,3 +1,5 @@
 const twoWpTests = require('../../lib/tests/2wp');
 
-twoWpTests.executeShort('BTC <=> RSK 2WP after p2wsh federation change');
+twoWpTests.executeShort(
+    '@smoke @regression @2wp @pegin @pegout BTC <=> RSK 2WP after p2wsh federation change'
+);

--- a/tests/01_powpeg/extra/01-vote_for_locking_cap_to_21m.js
+++ b/tests/01_powpeg/extra/01-vote_for_locking_cap_to_21m.js
@@ -7,7 +7,7 @@ const { expect } = require('chai');
 const lockingCapAuthorizerPrivateKey =
     'da6a5451bfd74829307ec6d4a8c55174d4859169f162a8ed8fcba8f7636e77cc';
 
-describe('Vote for locking cap to the max 21 million btc', function () {
+describe('@regression @bridge-methods Vote for locking cap to the max 21 million btc', function () {
     let rskTxHelpers;
 
     before(async () => {

--- a/tests/01_powpeg/extra/02-fee_per_kb.js
+++ b/tests/01_powpeg/extra/02-fee_per_kb.js
@@ -11,7 +11,7 @@ const {
 
 const RANDOM_ADDR = '42a3d6e125aad539ac15ed04e1478eb0a4dc1489';
 
-describe('Fee per kb change voting', function () {
+describe('@regression @bridge-methods Fee per kb change voting', function () {
     let rskTxHelper;
     let bridge;
 

--- a/tests/01_powpeg/extra/03-powpeg_redeem_script.js
+++ b/tests/01_powpeg/extra/03-powpeg_redeem_script.js
@@ -9,7 +9,7 @@ const CustomError = require('../../../lib/CustomError');
 const removePrefix0x = require('../../../lib/utils').removePrefix0x;
 const { ERP_PUBKEYS, ERP_CSV_VALUE } = require('../../../lib/constants/federation-constants');
 
-describe('Calling getActivePowpegRedeemScript method', function () {
+describe('@regression @federation-change Calling getActivePowpegRedeemScript method', function () {
     let rskTxHelper;
     let bridge;
 

--- a/tests/01_powpeg/extra/03-powpeg_redeem_script.js
+++ b/tests/01_powpeg/extra/03-powpeg_redeem_script.js
@@ -9,7 +9,7 @@ const CustomError = require('../../../lib/CustomError');
 const removePrefix0x = require('../../../lib/utils').removePrefix0x;
 const { ERP_PUBKEYS, ERP_CSV_VALUE } = require('../../../lib/constants/federation-constants');
 
-describe('@regression @federation-change Calling getActivePowpegRedeemScript method', function () {
+describe('@regression @bridge-methods Calling getActivePowpegRedeemScript method', function () {
     let rskTxHelper;
     let bridge;
 

--- a/tests/01_powpeg/extra/04-change-federation-full.js
+++ b/tests/01_powpeg/extra/04-change-federation-full.js
@@ -1,6 +1,6 @@
 const federationChangeTests = require('../../../lib/tests/change-federation');
 
 federationChangeTests.executeFull(
-    'Full Federation change from p2wsh to third federation with all intermediate validations',
+    '@regression @federation-change Full Federation change from p2wsh to third federation with all intermediate validations',
     Runners.config.federations.thirdFederation
 );

--- a/tests/01_powpeg/extra/05-2wp-full.js
+++ b/tests/01_powpeg/extra/05-2wp-full.js
@@ -1,3 +1,3 @@
 const twoWpTests = require('../../../lib/tests/2wp');
 
-twoWpTests.executeFull('BTC <=> RSK 2WP full suite');
+twoWpTests.executeFull('@regression @2wp @pegin @pegout BTC <=> RSK 2WP full suite');

--- a/tests/01_powpeg/extra/06-calls-to-bridge-methods-work.js
+++ b/tests/01_powpeg/extra/06-calls-to-bridge-methods-work.js
@@ -1,6 +1,6 @@
 const bridgeCallsTests = require('../../../lib/tests/bridge-calls');
 
 bridgeCallsTests.execute(
-    'Bridge calls and txs from contracts to constant fns',
+    '@regression @bridge-methods Bridge calls and txs from contracts to constant fns',
     () => Runners.hosts.federate.host
 );

--- a/tests/01_powpeg/extra/07-lock_whitelist_fork.js
+++ b/tests/01_powpeg/extra/07-lock_whitelist_fork.js
@@ -15,7 +15,7 @@ let rskTxHelper;
 let rskTxHelpers;
 let bridge;
 
-describe('Whitelist methods tests', () => {
+describe('@regression @bridge-methods @fork-activation Whitelist methods tests', () => {
     before(async () => {
         rskTxHelpers = getRskTransactionHelpers();
         rskTxHelper = rskTxHelpers[0];

--- a/tests/01_powpeg/extra/07-lock_whitelist_fork.js
+++ b/tests/01_powpeg/extra/07-lock_whitelist_fork.js
@@ -15,7 +15,7 @@ let rskTxHelper;
 let rskTxHelpers;
 let bridge;
 
-describe('@regression @bridge-methods @fork-activation Whitelist methods tests', () => {
+describe('@regression @bridge-methods Whitelist methods tests', () => {
     before(async () => {
         rskTxHelpers = getRskTransactionHelpers();
         rskTxHelper = rskTxHelpers[0];

--- a/tests/01_powpeg/extra/08-fed_pubkeys_fork.js
+++ b/tests/01_powpeg/extra/08-fed_pubkeys_fork.js
@@ -15,7 +15,7 @@ let rskTxHelper;
 let fedChangeAddress;
 let bridge;
 
-describe('Bridge federator methods tests', () => {
+describe('@regression @bridge-methods @fork-activation Bridge federator methods tests', () => {
     before(async () => {
         rskTxHelper = getRskTransactionHelper();
         fedChangeAddress = await rskTxHelper.importAccount(FEDERATION_CHANGE_PK);

--- a/tests/01_powpeg/extra/08-fed_pubkeys_fork.js
+++ b/tests/01_powpeg/extra/08-fed_pubkeys_fork.js
@@ -15,7 +15,7 @@ let rskTxHelper;
 let fedChangeAddress;
 let bridge;
 
-describe('@regression @bridge-methods @fork-activation Bridge federator methods tests', () => {
+describe('@regression @bridge-methods Bridge federator methods tests', () => {
     before(async () => {
         rskTxHelper = getRskTransactionHelper();
         fedChangeAddress = await rskTxHelper.importAccount(FEDERATION_CHANGE_PK);

--- a/tests/01_powpeg/extra/09-coinbase_information.js
+++ b/tests/01_powpeg/extra/09-coinbase_information.js
@@ -8,7 +8,7 @@ const { getBtcClient } = require('../../../lib/btc-client-provider');
 const btcEthUnitConverter = require('@rsksmart/btc-eth-unit-converter');
 const { getRskTransactionHelpers } = require('../../../lib/rsk-tx-helper-provider');
 
-describe('Calling coinbase information methods', () => {
+describe('@regression @bridge-methods Calling coinbase information methods', () => {
     let btcClient;
     let rskTxHelper;
     let rskTxHelpers;

--- a/tests/01_powpeg/extra/10-get_estimated_fees_methods.js
+++ b/tests/01_powpeg/extra/10-get_estimated_fees_methods.js
@@ -1,3 +1,5 @@
 const getEstimatedFeesMethodsTests = require('../../../lib/tests/get_estimated_fees_methods');
 
-getEstimatedFeesMethodsTests.execute('Bridge peg-out fee estimation methods');
+getEstimatedFeesMethodsTests.execute(
+    '@regression @bridge-methods Bridge peg-out fee estimation methods'
+);

--- a/tests/01_powpeg/extra/11-union-bridge-methods.js
+++ b/tests/01_powpeg/extra/11-union-bridge-methods.js
@@ -1,3 +1,3 @@
 const unionBridgeTests = require('../../../lib/tests/union-bridge-methods');
 
-unionBridgeTests.execute('@regression @union-bridge Union Bridge functionality tests');
+unionBridgeTests.execute('@regression @bridge-methods Union Bridge functionality tests');

--- a/tests/01_powpeg/extra/11-union-bridge-methods.js
+++ b/tests/01_powpeg/extra/11-union-bridge-methods.js
@@ -1,3 +1,3 @@
 const unionBridgeTests = require('../../../lib/tests/union-bridge-methods');
 
-unionBridgeTests.execute('Union Bridge functionality tests');
+unionBridgeTests.execute('@regression @union-bridge Union Bridge functionality tests');

--- a/tests/01_powpeg/extra/12-block-header-precompile.js
+++ b/tests/01_powpeg/extra/12-block-header-precompile.js
@@ -74,7 +74,7 @@ function bytesHexToBlockHashHex(hex) {
     return `0x${hashHex}`.toLowerCase();
 }
 
-describe('BlockHeader native precompile (0x…1000010)', () => {
+describe('@regression @bridge-methods BlockHeader native precompile (0x…1000010)', () => {
     let rskTxHelper;
     let blockHeader;
 

--- a/tests/01_powpeg/extra/12-block-header-precompile.js
+++ b/tests/01_powpeg/extra/12-block-header-precompile.js
@@ -74,7 +74,7 @@ function bytesHexToBlockHashHex(hex) {
     return `0x${hashHex}`.toLowerCase();
 }
 
-describe('@regression @bridge-methods BlockHeader native precompile (0x…1000010)', () => {
+describe('@regression @bridge-methods @precompiled BlockHeader native precompile (0x…1000010)', () => {
     let rskTxHelper;
     let blockHeader;
 

--- a/tests/01_powpeg/extra/13-registerFastBridgeBtcTransaction_user_call.js
+++ b/tests/01_powpeg/extra/13-registerFastBridgeBtcTransaction_user_call.js
@@ -7,7 +7,7 @@ const {
     UNPROCESSABLE_TX_NOT_CONTRACT_ERROR,
 } = require('../../../lib/flyover-pegin-response-codes');
 
-describe('Calling registerFastBridgeBtcTransaction', function () {
+describe('@regression @flyover Calling registerFastBridgeBtcTransaction', function () {
     let rskTxHelper;
     let btcTxHelper;
     let bridge;

--- a/tests/01_powpeg/extra/14-call_receive_headers.js
+++ b/tests/01_powpeg/extra/14-call_receive_headers.js
@@ -1,3 +1,6 @@
 const receiveHeadersTests = require('../../../lib/tests/call_receive_headers');
 
-receiveHeadersTests.execute('Calling receiveHeaders', () => Runners.hosts.federate.host);
+receiveHeadersTests.execute(
+    '@regression @bridge-methods Calling receiveHeaders',
+    () => Runners.hosts.federate.host
+);

--- a/tests/01_powpeg/extra/15-call_receive_header.js
+++ b/tests/01_powpeg/extra/15-call_receive_header.js
@@ -1,3 +1,3 @@
 const receiveHeaderTests = require('../../../lib/tests/call_receive_header');
 
-receiveHeaderTests.execute('Calling receiveHeader');
+receiveHeaderTests.execute('@regression @bridge-methods Calling receiveHeader');

--- a/tests/01_powpeg/extra/99-flyover_sending_same_tx_with_witness_twice.js
+++ b/tests/01_powpeg/extra/99-flyover_sending_same_tx_with_witness_twice.js
@@ -15,7 +15,7 @@ const { getBridge } = require('../../../lib/bridge-provider');
 const { mineForPeginRegistration } = require('../../../lib/2wp-utils');
 
 // TODO: Fails with 'Internal AssertionError: expected 40000000000000000 to equal -304' error. Pending to analyze.
-describe.skip('Executing registerFastBridgeBtcTransaction post hop - sending same tx with witness twice', () => {
+describe.skip('@regression @flyover Executing registerFastBridgeBtcTransaction post hop - sending same tx with witness twice', () => {
     let rskTxHelpers;
     let rskTxHelper;
     let btcTxHelper;

--- a/tests/01_powpeg/extra/99-flyover_sending_same_tx_without_witness_twice.js
+++ b/tests/01_powpeg/extra/99-flyover_sending_same_tx_without_witness_twice.js
@@ -15,7 +15,7 @@ const { getBridge } = require('../../../lib/bridge-provider');
 const { mineForPeginRegistration } = require('../../../lib/2wp-utils');
 
 // TODO: Fails with 'Internal AssertionError: expected 40000000000000000 to equal -304' error. Pending to analyze.
-describe.skip('Executing registerFastBridgeBtcTransaction post hop - sending same tx without witness twice', () => {
+describe.skip('@regression @flyover Executing registerFastBridgeBtcTransaction post hop - sending same tx without witness twice', () => {
     let rskTxHelpers;
     let rskTxHelper;
     let btcTxHelper;

--- a/tests/01_powpeg/extra/99-register_fast_bridge_btc_below_minimum.js
+++ b/tests/01_powpeg/extra/99-register_fast_bridge_btc_below_minimum.js
@@ -16,7 +16,7 @@ const { mineForPeginRegistration } = require('../../../lib/2wp-utils');
 // TODO: Refactor these tests
 // Some tests fail after running all tests with all forks active from scratch.
 // More analysis need to be done. Also, these tests use legacy functions. We need to refactor them.
-describe.skip('Executing registerFastBridgeBtcTransaction after hop - send funds below minimum', () => {
+describe.skip('@regression @flyover Executing registerFastBridgeBtcTransaction after hop - send funds below minimum', () => {
     let rskTxHelpers;
     let rskTxHelper;
     let btcTxHelper;

--- a/tests/01_powpeg/extra/99-register_flyover_btc_transaction.js
+++ b/tests/01_powpeg/extra/99-register_flyover_btc_transaction.js
@@ -17,7 +17,7 @@ let btcTxHelper;
 let bridge;
 
 // TODO: Fails with 'Internal AssertionError: expected -304 to equal 20000000000000000000' error. Pending to analyze.
-describe.skip('Calling registerFastBridgeBtcTransaction after iris', () => {
+describe.skip('@regression @flyover Calling registerFastBridgeBtcTransaction after iris', () => {
     before(async () => {
         rskTxHelpers = getRskTransactionHelpers();
         rskTxHelper = rskTxHelpers[0];


### PR DESCRIPTION
This pull request introduces a tagging system for test cases and updates the test suite to support running tests by tag using Mocha's `--grep` feature. It adds documentation, new npm scripts for common tag subsets, and applies tags to existing test files to enable targeted test runs (such as smoke or regression tests). This will make it easier and faster to run relevant subsets of tests during development and CI.

The most important changes are:

**Test Tagging and Selection:**
* Added a section to `README.md` explaining the new tagging system, tag vocabulary, and usage instructions for running tests by tag with Mocha's `--grep` option.
* Added npm scripts `test:smoke` and `test:regression` to `package.json` for running the `@smoke` and `@regression` test subsets, respectively.

**Tagging of Test Cases:**
* Updated all major test files and suites to include appropriate tags (such as `@smoke`, `@regression`, `@sync`, `@federation-change`, `@2wp`, `@pegin`, `@pegout`, `@flyover`, `@union-bridge`, `@fork-activation`, and `@bridge-methods`) in their `describe` or test titles. This enables fine-grained selection of tests based on area or purpose.

**Convenience and Reliability:**
* Provided guidance in the documentation about the importance of test execution order and the limitations of running arbitrary tag combinations, to help users avoid state-related test failures.

**Future direction:**
* The tagging system is intended to eventually **replace the current `short`/`full` (`TEST_SUITE`) mechanism**, which is coarser and folder-based. Tags are much richer and more flexible — they allow selecting by behaviour area and by purpose, and compose freely — whereas `short`/`full` can only include/exclude the `extra/` folders. For now the two coexist (today `test:smoke` and `test-short` select the same set); the `short`/`full` retirement, and wiring tags into CI/`workflow_dispatch` scoping, are deliberately left as follow-ups (P2-03).

These changes make it much easier to run focused subsets of tests for faster feedback and more efficient CI workflows.