### PR TITLE
Strengthen assertions

### DIFF
--- a/lib/2wp-utils.js
+++ b/lib/2wp-utils.js
@@ -1,7 +1,7 @@
 const expect = require('chai').expect;
 const {
     sendFromCow,
-    mineAndSync,
+    mineWithSubmitterAndSync,
     waitForRskMempoolToGetNewTxs,
     waitAndUpdateBridge,
 } = require('./rsk-utils');
@@ -19,7 +19,6 @@ const { PEGIN_EVENTS, DEFAULT_RSK_ADDRESS_FUNDING_IN_BTC } = require('./constant
 const { PEGOUT_EVENTS } = require('./constants/pegout-constants');
 
 const peginVerifier = require('pegin-address-verificator');
-const { getRskTransactionHelpers } = require('../lib/rsk-tx-helper-provider');
 const { getLogger } = require('../logger');
 
 const {
@@ -92,7 +91,7 @@ const sendTxToBridge = async (rskTxHelper, amountInWeisBN, rskFromAddress, mine 
     // Wait for the rsk tx to be in the rsk mempool before mining
     await waitForRskMempoolToGetNewTxs(rskTxHelper);
 
-    await mineAndSync(getRskTransactionHelpers());
+    await mineWithSubmitterAndSync(rskTxHelper);
     const result = await txPromise;
     return result;
 };
@@ -113,9 +112,16 @@ const createPegoutRequest = async (rskTxHelper, amountInRBTC, requestSize = 1) =
     await sendFromCow(rskTxHelper, rskAddress, PEGOUT_AMOUNT_PLUS_FEE);
     await rskTxHelper.unlockAccount(rskAddress);
     for (let i = 0; i < requestSize; i++) {
-        await sendTxToBridge(rskTxHelper, new BN(ethToWeis(amountInRBTC)), rskAddress, false);
+        await sendTxToBridge(
+            rskTxHelper,
+            new BN(btcEthUnitConverter.ethToWeis(amountInRBTC)),
+            rskAddress,
+            false
+        );
     }
-    await mineAndSync(getRskTransactionHelpers());
+    // The pegout request txs were all submitted through `rskTxHelper`, so mine with that
+    // same node to make sure they get included.
+    await mineWithSubmitterAndSync(rskTxHelper);
 };
 
 const getActiveFederationUtxos = async (rskTxHelper) => {

--- a/lib/rsk-utils.js
+++ b/lib/rsk-utils.js
@@ -376,7 +376,7 @@ const waitForRskTxToBeInTheMempool = async (
  */
 const waitForRskMempoolToGetNewTxs = async (
     rskTxHelper,
-    maxAttempts = 3,
+    maxAttempts = 10,
     checkEveryMilliseconds = 500
 ) => {
     const initialRskMempoolTxs = await getRskMempoolTransactionsToTheBridge(rskTxHelper);

--- a/lib/rsk-utils.js
+++ b/lib/rsk-utils.js
@@ -320,11 +320,14 @@ const waitForRskMempoolToGetThisCountOfRegisterBtcTx = async (
     );
 };
 
+// The `updateCollections` tx is submitted locally by the same node right after the
+// `fed_updateBridge` call, so it should reach the mempool quickly. A short budget is
+// enough, and fails fast when the tx is never going to show up.
 const waitForRskMempoolToGetThisCountOfUpdateCollectionsTxs = async (
     rskTxHelper,
     expectedCount,
-    maxAttempts = 24,
-    checkEveryMilliseconds = 2000
+    maxAttempts = 10,
+    checkEveryMilliseconds = 1000
 ) => {
     return waitForRskMempoolToGetThisCountOfThisTxType(
         rskTxHelper,

--- a/lib/rsk-utils.js
+++ b/lib/rsk-utils.js
@@ -193,10 +193,22 @@ const waitAndUpdateBridge = async (
     shouldMineAndSync = true
 ) => {
     await wait(timeInMilliseconds);
+
+    // Count the `updateCollections` txs already in the mempool, to detect the new one
+    // triggered by the `updateBridge` call below.
+    const initialMempoolTxs = await getRskMempoolTransactionsToTheBridge(rskTxHelper, true);
+    const initialUpdateCollectionsTxsCount = initialMempoolTxs.filter((tx) =>
+        tx.input?.startsWith(BRIDGE_TX_TYPES.UPDATE_COLLECTIONS.methodSelector)
+    ).length;
+
     await rskTxHelper.updateBridge();
 
-    // Wait for the rsk `updateBridge` tx to be in the rsk mempool before mining
-    await waitForRskMempoolToGetNewTxs(rskTxHelper);
+    // Wait for the new `updateCollections` tx to be in this node's mempool before mining,
+    // to ensure it gets included in the block mined below.
+    await waitForRskMempoolToGetThisCountOfUpdateCollectionsTxs(
+        rskTxHelper,
+        initialUpdateCollectionsTxsCount + 1
+    );
 
     if (shouldMineAndSync) {
         // Mine with the same node that submitted the `updateBridge` tx, since it is
@@ -230,6 +242,10 @@ const BRIDGE_TX_TYPES = {
     REGISTER_BTC_TRANSACTION: {
         methodSelector: '0x43dc0656',
         name: 'registerBtcTransaction',
+    },
+    UPDATE_COLLECTIONS: {
+        methodSelector: '0x0c5a9990',
+        name: 'updateCollections',
     },
 };
 
@@ -301,6 +317,21 @@ const waitForRskMempoolToGetThisCountOfRegisterBtcTx = async (
         maxAttempts,
         checkEveryMilliseconds,
         onEachAttempt
+    );
+};
+
+const waitForRskMempoolToGetThisCountOfUpdateCollectionsTxs = async (
+    rskTxHelper,
+    expectedCount,
+    maxAttempts = 24,
+    checkEveryMilliseconds = 2000
+) => {
+    return waitForRskMempoolToGetThisCountOfThisTxType(
+        rskTxHelper,
+        BRIDGE_TX_TYPES.UPDATE_COLLECTIONS,
+        expectedCount,
+        maxAttempts,
+        checkEveryMilliseconds
     );
 };
 
@@ -928,6 +959,7 @@ module.exports = {
     compressPublicKey,
     waitForRskMempoolToGetThisCountOfAddSignatureTxs,
     waitForRskMempoolToGetThisCountOfRegisterBtcTx,
+    waitForRskMempoolToGetThisCountOfUpdateCollectionsTxs,
     importAccounts,
     decodeLogs,
     assertContractCallFails,

--- a/lib/rsk-utils.js
+++ b/lib/rsk-utils.js
@@ -410,7 +410,7 @@ const waitForRskMempoolToGetNewTxs = async (
     maxAttempts = 10,
     checkEveryMilliseconds = 500
 ) => {
-    const initialRskMempoolTxs = await getRskMempoolTransactionsToTheBridge(rskTxHelper);
+    const initialRskMempoolTxs = await getRskMempoolTransactionsToTheBridge(rskTxHelper, true);
 
     logger.debug(
         `[${waitForRskMempoolToGetNewTxs.name}] initial rsk mempool size: ${initialRskMempoolTxs.length}`
@@ -420,10 +420,10 @@ const waitForRskMempoolToGetNewTxs = async (
     );
 
     const areThereNewTxsInTheMempool = async () => {
-        const mempoolTxHashes = await getRskMempoolTransactionsToTheBridge(rskTxHelper);
-        if (mempoolTxHashes.length > initialRskMempoolTxs.length) {
+        const mempoolTxs = await getRskMempoolTransactionsToTheBridge(rskTxHelper, true);
+        if (mempoolTxs.length > initialRskMempoolTxs.length) {
             logger.debug(
-                `[${waitForRskMempoolToGetNewTxs.name}] The mempool got ${mempoolTxHashes.length - initialRskMempoolTxs.length} new transactions`
+                `[${waitForRskMempoolToGetNewTxs.name}] The mempool got ${mempoolTxs.length - initialRskMempoolTxs.length} new transactions`
             );
             return true;
         }
@@ -441,10 +441,10 @@ const waitForRskMempoolToGetNewTxs = async (
         checkEveryMilliseconds
     );
 
-    const finalRskMempoolTxHashes = await getRskMempoolTransactionsToTheBridge(rskTxHelper);
+    const finalRskMempoolTxs = await getRskMempoolTransactionsToTheBridge(rskTxHelper, true);
 
     logger.debug(
-        `[${waitForRskMempoolToGetNewTxs.name}] final rsk mempool size: ${finalRskMempoolTxHashes.length}, after ${attempts} attempts. Difference with initial mempool size: ${finalRskMempoolTxHashes.length - initialRskMempoolTxs.length}`
+        `[${waitForRskMempoolToGetNewTxs.name}] final rsk mempool size: ${finalRskMempoolTxs.length}, after ${attempts} attempts. Difference with initial mempool size: ${finalRskMempoolTxs.length - initialRskMempoolTxs.length}`
     );
 
     return newTxsWhereFoundInTheRskMempool;
@@ -791,7 +791,7 @@ const waitForRskMempoolToGetAtLeastThisManyTxs = async (
 ) => {
     let attempts = 1;
     while (attempts <= maxAttempts) {
-        const rskMempoolTxs = await getRskMempoolTransactionsToTheBridge(rskTxHelper);
+        const rskMempoolTxs = await getRskMempoolTransactionsToTheBridge(rskTxHelper, true);
         logger.debug(
             `[${waitForRskMempoolToGetAtLeastThisManyTxs.name}] rsk mempool txs: ${rskMempoolTxs.length}`
         );

--- a/lib/rsk-utils.js
+++ b/lib/rsk-utils.js
@@ -140,6 +140,21 @@ const mineAndSync = async (rskTransactionHelpers, blocksToMine = 1) => {
 };
 
 /**
+ * Mines with the `submitterTxHelper`'s node, so the txs in its mempool get included in the
+ * mined blocks without depending on tx propagation, and makes sure the other federator nodes sync.
+ * @param {RskTransactionHelper} submitterTxHelper the node that has the submitted txs in its mempool
+ * @param {Number} blocksToMine Defaults to 1 if not provided
+ * @returns {Promise<Array<Number>>} An array of block numbers, one for each federator node
+ */
+const mineWithSubmitterAndSync = async (submitterTxHelper, blocksToMine = 1) => {
+    const submitterHost = submitterTxHelper.getClient().currentProvider.host;
+    const otherTxHelpers = getRskTransactionHelpers().filter(
+        (txHelper) => txHelper.getClient().currentProvider.host !== submitterHost
+    );
+    return await mineAndSync([submitterTxHelper, ...otherTxHelpers], blocksToMine);
+};
+
+/**
  * Sends `amountInWeis` funds from the `cow` account to the `recipientAddress`
  * @param {RskTransactionHelper} rskTxHelper to make transactions to the rsk network
  * @param {String} recipientAddress address to receive the funds
@@ -155,8 +170,14 @@ const sendFromCow = async (rskTxHelper, recipientAddress, amountInWeis) => {
         value: amountInWeis,
     });
 
-    await wait(1000);
-    await mineAndSync(getRskTransactionHelpers());
+    // The node emits the tx hash once it accepts the tx into its mempool, so after this
+    // point the tx is ready to be included in a block mined by this same node.
+    await new Promise((resolve, reject) => {
+        txPromise.once('transactionHash', resolve);
+        txPromise.once('error', reject);
+    });
+
+    await mineWithSubmitterAndSync(rskTxHelper);
     await txPromise;
 
     const finalBalance = await rskTxHelper.getBalance(recipientAddress);
@@ -211,13 +232,7 @@ const waitAndUpdateBridge = async (
     );
 
     if (shouldMineAndSync) {
-        // Mine with the same node that submitted the `updateBridge` tx, since it is
-        // the one that has it in its mempool, and sync the rest.
-        const submitterHost = rskTxHelper.getClient().currentProvider.host;
-        const otherTxHelpers = getRskTransactionHelpers().filter(
-            (txHelper) => txHelper.getClient().currentProvider.host !== submitterHost
-        );
-        await mineAndSync([rskTxHelper, ...otherTxHelpers]);
+        await mineWithSubmitterAndSync(rskTxHelper);
     }
 };
 
@@ -574,7 +589,7 @@ const sendTransaction = async (rskTxHelper, method, from, valueInWeis = 0, gas =
     const txReceiptPromise = method.send({ from, value: valueInWeis, gas });
 
     await waitForRskMempoolToGetNewTxs(rskTxHelper);
-    await mineAndSync(getRskTransactionHelpers());
+    await mineWithSubmitterAndSync(rskTxHelper);
 
     return await txReceiptPromise;
 };
@@ -936,6 +951,7 @@ const assertIsPublicKey = (s) => {
 
 module.exports = {
     mineAndSync,
+    mineWithSubmitterAndSync,
     waitForBlock,
     sendFromCow,
     getMaxBlockNumber,

--- a/lib/tests/change-federation.js
+++ b/lib/tests/change-federation.js
@@ -1476,33 +1476,20 @@ const execute = (description, newFederationConfig, fullExecution = false) => {
                 );
 
                 // Triggers `fed_updateBridge` on this member's node, making it send an
-                // `updateCollections` tx signed with its own key.
-                await fedTxHelper.updateBridge();
+                // `updateCollections` tx signed with its own key, and mines it with this
+                // same node.
+                await rskUtils.waitAndUpdateBridge(fedTxHelper);
 
-                // Wait for this member's `updateCollections` tx to reach the mempool.
-                const { result: updateCollectionsTx } = await retryWithCheck(
-                    async () => {
-                        const bridgeMempoolTxs =
-                            await rskUtils.getRskMempoolTransactionsToTheBridge(fedTxHelper, true);
-                        return bridgeMempoolTxs.find(
-                            (tx) =>
-                                tx.from.toLowerCase() === fedRskAddress.toLowerCase() &&
-                                tx.input === updateCollectionsData
-                        );
-                    },
-                    (tx) => tx !== undefined
+                const latestBlock = await fedTxHelper.getClient().eth.getBlock('latest', true);
+                const updateCollectionsTx = latestBlock.transactions.find(
+                    (tx) =>
+                        tx.from.toLowerCase() === fedRskAddress.toLowerCase() &&
+                        tx.input === updateCollectionsData
                 );
                 expect(
                     updateCollectionsTx,
-                    `The updateCollections tx from the federate at ${federates[i].host} was not found in the mempool.`
+                    `The updateCollections tx from the federate at ${federates[i].host} was not mined.`
                 ).to.not.be.undefined;
-
-                // Mine with this member's node, since it is the one that has the
-                // `updateCollections` tx in its mempool, and sync the rest.
-                await rskUtils.mineAndSync([
-                    fedTxHelper,
-                    ...rskTxHelpers.filter((txHelper) => txHelper !== fedTxHelper),
-                ]);
 
                 const receipt = await fedTxHelper
                     .getClient()


### PR DESCRIPTION
This pull request refactors how transactions are mined and synchronized in the RSK test utilities, making mining behavior more reliable by ensuring that the node which submitted a transaction is responsible for mining it. It also improves detection and handling of `updateCollections` transactions, and updates tests accordingly.

**Mining and Synchronization Improvements:**

* Introduced `mineWithSubmitterAndSync`, a new utility that mines blocks with the node that submitted transactions, ensuring those transactions are included without relying on mempool propagation. Updated all relevant calls from the old `mineAndSync` to the new method for more deterministic test behavior. (`lib/rsk-utils.js`, `lib/2wp-utils.js`) [[1]](diffhunk://#diff-5ae6cb268232abc556725fd7b7c48ea39c206a51ca4ca4c3b4e122fbe24c741aR142-R156) [[2]](diffhunk://#diff-5ae6cb268232abc556725fd7b7c48ea39c206a51ca4ca4c3b4e122fbe24c741aR954) [[3]](diffhunk://#diff-4fed9ac4774321969d5aefb68bbfcdc7bb81d52cef565c20361a776485e74ac3L4-R4) [[4]](diffhunk://#diff-4fed9ac4774321969d5aefb68bbfcdc7bb81d52cef565c20361a776485e74ac3L95-R94) [[5]](diffhunk://#diff-4fed9ac4774321969d5aefb68bbfcdc7bb81d52cef565c20361a776485e74ac3L116-R124) [[6]](diffhunk://#diff-5ae6cb268232abc556725fd7b7c48ea39c206a51ca4ca4c3b4e122fbe24c741aL543-R592)

* Updated `sendFromCow`, `sendTransaction`, and other transaction-sending functions to use `mineWithSubmitterAndSync` for improved reliability. [[1]](diffhunk://#diff-5ae6cb268232abc556725fd7b7c48ea39c206a51ca4ca4c3b4e122fbe24c741aL158-R180) [[2]](diffhunk://#diff-5ae6cb268232abc556725fd7b7c48ea39c206a51ca4ca4c3b4e122fbe24c741aL543-R592)

**`updateCollections` Transaction Handling:**

* Added logic to track and wait for `updateCollections` transactions in the mempool, including a new method `waitForRskMempoolToGetThisCountOfUpdateCollectionsTxs` and an updated `BRIDGE_TX_TYPES` constant. [[1]](diffhunk://#diff-5ae6cb268232abc556725fd7b7c48ea39c206a51ca4ca4c3b4e122fbe24c741aR261-R264) [[2]](diffhunk://#diff-5ae6cb268232abc556725fd7b7c48ea39c206a51ca4ca4c3b4e122fbe24c741aR338-R355) [[3]](diffhunk://#diff-5ae6cb268232abc556725fd7b7c48ea39c206a51ca4ca4c3b4e122fbe24c741aR981)

* Refactored `waitAndUpdateBridge` to reliably detect when a new `updateCollections` transaction appears in the mempool and ensure it is mined with the submitting node.

**Test Improvements:**

* Simplified the federation change test to use the improved `waitAndUpdateBridge` and to directly check for the mined `updateCollections` transaction, removing redundant mining and mempool checks. (`lib/tests/change-federation.js`)

**General Reliability Improvements:**

* Increased polling attempts in `waitForRskMempoolToGetNewTxs` and ensured all mempool queries use the correct parameters for full transaction details. [[1]](diffhunk://#diff-5ae6cb268232abc556725fd7b7c48ea39c206a51ca4ca4c3b4e122fbe24c741aL379-R431) [[2]](diffhunk://#diff-5ae6cb268232abc556725fd7b7c48ea39c206a51ca4ca4c3b4e122fbe24c741aL392-R444) [[3]](diffhunk://#diff-5ae6cb268232abc556725fd7b7c48ea39c206a51ca4ca4c3b4e122fbe24c741aL413-R465) [[4]](diffhunk://#diff-5ae6cb268232abc556725fd7b7c48ea39c206a51ca4ca4c3b4e122fbe24c741aL763-R812)

These changes collectively make the test suite more reliable and deterministic by ensuring that transactions are always mined by the node that submitted them, and by improving the detection and handling of key bridge transactions.