### PR TITLE
[P1 02] pr reporting and timing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,14 @@ jobs:
           path: reports/junit.xml
           if-no-files-found: warn
 
+      # Render the JUnit report (and per-phase timing, when present) into the run summary.
+      # always() so the breakdown is produced on failing runs too; the script never exits
+      # non-zero, so it cannot turn a passing run red. Per-file durations here are the input
+      # the sharding work (P2-01/P2-02) uses to balance shards against the serial baseline.
+      - name: Test timing summary
+        if: always()
+        run: node scripts/ci-timing-summary.js reports/junit.xml reports/phase-timing.json >> "$GITHUB_STEP_SUMMARY"
+
       - name: Check Slack Token
         id: check-slack-token
         # always() so this still runs (and the failure-notification step can gate on its output)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,11 +189,14 @@ jobs:
         run: node scripts/ci-timing-summary.js reports/junit.xml reports/phase-timing.json >> "$GITHUB_STEP_SUMMARY"
 
       # Surface failing tests as a PR check with per-test annotations instead of only in the
-      # ~40-min raw log. always() so failures are reported; fail-on-error/fail-on-empty false
-      # so a missing report or a fork PR's read-only token never turns the run red on top of
-      # the real result.
+      # ~40-min raw log. always() so failures are still reported. Skipped for fork PRs, whose
+      # read-only token can't create the check (they'd only produce a confusing failed-but-
+      # ignored step); fail-on-error/fail-on-empty stay false as a guard for empty reports.
       - name: Publish test report (PR annotations)
-        if: always()
+        if: >-
+          always() &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository)
         uses: dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3 # v3.0.0
         with:
           name: RIT Test Results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,13 @@ jobs:
     name: Rootstock Integration Tests
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # checks: write lets the test-reporter publish failures as a PR check with annotations.
+    # (Job-level perms replace the top-level default, so contents: read is re-declared here.)
+    # Note: PRs from forks always get a read-only token, so the annotation check is skipped
+    # for them — the step is set to not fail the job in that case.
+    permissions:
+      contents: read
+      checks: write
 
     steps:
       - name: Checkout
@@ -180,6 +187,20 @@ jobs:
       - name: Test timing summary
         if: always()
         run: node scripts/ci-timing-summary.js reports/junit.xml reports/phase-timing.json >> "$GITHUB_STEP_SUMMARY"
+
+      # Surface failing tests as a PR check with per-test annotations instead of only in the
+      # ~40-min raw log. always() so failures are reported; fail-on-error/fail-on-empty false
+      # so a missing report or a fork PR's read-only token never turns the run red on top of
+      # the real result.
+      - name: Publish test report (PR annotations)
+        if: always()
+        uses: dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3 # v3.0.0
+        with:
+          name: RIT Test Results
+          path: reports/junit.xml
+          reporter: java-junit
+          fail-on-error: false
+          fail-on-empty: false
 
       - name: Check Slack Token
         id: check-slack-token

--- a/lib/phase-timing.js
+++ b/lib/phase-timing.js
@@ -67,15 +67,21 @@ mark('suiteStart');
 
 // Root hooks give us suiteStart -> (mine) -> setupEnd -> lastTestEnd -> teardownEnd without
 // depending on hook ordering relative to the suite's teardown (the file is written on exit).
-if (typeof before === 'function') {
-    // First test to run marks the end of the one-time setup phase.
-    beforeEach(function () {
-        if (marks.setupEnd == null) {
-            mark('setupEnd');
-        }
-    });
-    // Updated after every test; after the last one it holds the end-of-tests timestamp.
-    afterEach(() => mark('lastTestEnd'));
+// Registered defensively: only when the mocha globals exist, and never letting a registration
+// error propagate into module load / the suite.
+try {
+    if (typeof beforeEach === 'function' && typeof afterEach === 'function') {
+        // First test to run marks the end of the one-time setup phase.
+        beforeEach(function () {
+            if (marks.setupEnd == null) {
+                mark('setupEnd');
+            }
+        });
+        // Updated after every test; after the last one it holds the end-of-tests timestamp.
+        afterEach(() => mark('lastTestEnd'));
+    }
+} catch {
+    // Diagnostic only — never disturb the run.
 }
 
 process.on('exit', writePhaseTiming);

--- a/lib/phase-timing.js
+++ b/lib/phase-timing.js
@@ -1,0 +1,76 @@
+/*
+ * Per-phase timing instrumentation for the RIT suite.
+ *
+ * The whole suite runs inside one opaque `docker run` step in CI, so the GitHub Actions step
+ * timing can't tell node-boot/mining from actual test execution. This module records that
+ * breakdown from inside the run and writes reports/phase-timing.json, which
+ * scripts/ci-timing-summary.js renders into the run summary. That setup-vs-test split is the
+ * signal the sharding work (P2-01/P2-02) needs to know where the ~40-min wall-clock goes.
+ *
+ * Requiring this module self-registers root mocha hooks; the caller (test.js) additionally
+ * brackets the initial-block mining with mark('mineStart')/mark('mineEnd'). Everything here is
+ * best-effort: it must never throw into the suite, so all bookkeeping is guarded and the file
+ * is written from a process 'exit' handler (which also runs on mocha's bail/early exit).
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const marks = {};
+
+const now = () => Date.now();
+
+// Record a named timestamp. Safe to call before/after the hooks below have run and safe to
+// call more than once (last write wins); never throws.
+const mark = (name) => {
+    try {
+        marks[name] = now();
+    } catch {
+        // Timing is diagnostic only — never let it disturb the run.
+    }
+};
+
+const seconds = (from, to) =>
+    marks[from] != null && marks[to] != null ? (marks[to] - marks[from]) / 1000 : null;
+
+const writePhaseTiming = () => {
+    try {
+        marks.teardownEnd = now();
+        // Prefer the mounted CI workspace so the file reaches the runner; fall back to CWD
+        // for local runs. Mirrors where mocha-junit-reporter's report is collected from.
+        const base = process.env.GITHUB_WORKSPACE || process.cwd();
+        const dir = path.join(base, 'reports');
+        fs.mkdirSync(dir, { recursive: true });
+
+        const data = {
+            setupSeconds: seconds('suiteStart', 'setupEnd'),
+            mineSeconds: seconds('mineStart', 'mineEnd'),
+            testsSeconds: seconds('setupEnd', 'lastTestEnd'),
+            teardownSeconds: seconds('lastTestEnd', 'teardownEnd'),
+            totalSeconds: seconds('suiteStart', 'teardownEnd'),
+        };
+        fs.writeFileSync(path.join(dir, 'phase-timing.json'), JSON.stringify(data, null, 2));
+    } catch {
+        // Best-effort: a failed write must not affect the test result.
+    }
+};
+
+// Root hooks. This module is required at the top of test.js, so these register before the
+// suite's own setup `before`, and the mine marks are set from within it — giving us
+// suiteStart -> (mine) -> setupEnd -> lastTestEnd -> teardownEnd without depending on hook
+// ordering relative to the suite's teardown (the file is written on process exit).
+if (typeof before === 'function') {
+    before(() => mark('suiteStart'));
+    // First test to run marks the end of the one-time setup phase.
+    beforeEach(function () {
+        if (marks.setupEnd == null) {
+            mark('setupEnd');
+        }
+    });
+    // Updated after every test; after the last one it holds the end-of-tests timestamp.
+    afterEach(() => mark('lastTestEnd'));
+}
+
+process.on('exit', writePhaseTiming);
+
+module.exports = { mark };

--- a/lib/phase-timing.js
+++ b/lib/phase-timing.js
@@ -35,10 +35,14 @@ const seconds = (from, to) =>
 
 const writePhaseTiming = () => {
     try {
+        // CI/container-only reporting: GITHUB_WORKSPACE is set on the runner and in the action
+        // container (where it is the mounted dir the report reaches the host through). Skipping
+        // it otherwise keeps a plain local `npm test` from leaving an untracked reports/ file.
+        const base = process.env.GITHUB_WORKSPACE;
+        if (!base) {
+            return;
+        }
         marks.teardownEnd = now();
-        // Prefer the mounted CI workspace so the file reaches the runner; fall back to CWD
-        // for local runs. Mirrors where mocha-junit-reporter's report is collected from.
-        const base = process.env.GITHUB_WORKSPACE || process.cwd();
         const dir = path.join(base, 'reports');
         fs.mkdirSync(dir, { recursive: true });
 
@@ -55,12 +59,15 @@ const writePhaseTiming = () => {
     }
 };
 
-// Root hooks. This module is required at the top of test.js, so these register before the
-// suite's own setup `before`, and the mine marks are set from within it — giving us
-// suiteStart -> (mine) -> setupEnd -> lastTestEnd -> teardownEnd without depending on hook
-// ordering relative to the suite's teardown (the file is written on process exit).
+// Start the "setup" clock at module load. This module is required at the top of test.js, so
+// this runs before the test-file requires and the suite's own setup `before` — so setupSeconds
+// includes suite bootstrap, not just the `before` hook. (Node/mocha startup before this require
+// is still excluded; the "setup" label is scoped accordingly.)
+mark('suiteStart');
+
+// Root hooks give us suiteStart -> (mine) -> setupEnd -> lastTestEnd -> teardownEnd without
+// depending on hook ordering relative to the suite's teardown (the file is written on exit).
 if (typeof before === 'function') {
-    before(() => mark('suiteStart'));
     // First test to run marks the end of the one-time setup phase.
     beforeEach(function () {
         if (marks.setupEnd == null) {

--- a/scripts/ci-timing-summary.js
+++ b/scripts/ci-timing-summary.js
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+/*
+ * CI timing summary — renders the JUnit report (and, when present, the per-phase
+ * timing file) as a Markdown table for the GitHub Actions run summary.
+ *
+ * Usage: node scripts/ci-timing-summary.js [path/to/junit.xml] [path/to/phase-timing.json]
+ *
+ * Writes Markdown to stdout; the workflow appends it to $GITHUB_STEP_SUMMARY. Designed to
+ * never fail the job: missing/unparyable inputs produce a note, not a non-zero exit. The
+ * primary consumer of this breakdown is the sharding work (P2-01/P2-02), which needs
+ * per-test-file durations to balance shards and to measure wall-clock against the baseline.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const junitPath = process.argv[2] || 'reports/junit.xml';
+const phasePath = process.argv[3] || 'reports/phase-timing.json';
+
+// Number of rows to show in the "slowest" tables; the full data lives in the artifact.
+const TOP_SLOWEST_FILES = 30;
+const TOP_SLOWEST_TESTS = 15;
+
+const out = (line = '') => process.stdout.write(line + '\n');
+
+const fmtDuration = (seconds) => {
+    if (!isFinite(seconds) || seconds < 0) {
+        return '—';
+    }
+    const total = Math.round(seconds);
+    const m = Math.floor(total / 60);
+    const s = total % 60;
+    return m > 0 ? `${m}m ${s}s` : `${s}s`;
+};
+
+const getAttr = (fragment, name) => {
+    const match = fragment.match(new RegExp(`\\b${name}="([^"]*)"`));
+    return match ? match[1] : null;
+};
+
+const decode = (str) =>
+    (str || '')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&apos;/g, "'")
+        .replace(/&amp;/g, '&');
+
+// Parse the mocha-junit-reporter output. Its shape is a flat list of <testsuite> elements
+// under a single <testsuites> root, each holding <testcase> children — so attribute-level
+// regex parsing is sufficient here (no nesting to track).
+function parseJunit(xml) {
+    const suiteRe = /<testsuite\b[^>]*?(?:\/>|>[\s\S]*?<\/testsuite>)/g;
+    const caseRe = /<testcase\b[^>]*?(?:\/>|>[\s\S]*?<\/testcase>)/g;
+
+    const files = new Map(); // key: file or suite name -> aggregated stats
+    const tests = []; // individual testcases, for the "slowest tests" table
+    let totalTests = 0;
+    let totalFailures = 0;
+    let totalSkipped = 0;
+
+    let suiteMatch;
+    while ((suiteMatch = suiteRe.exec(xml)) !== null) {
+        const suiteFragment = suiteMatch[0];
+        const suiteName = decode(getAttr(suiteFragment, 'name')) || '(unnamed)';
+        // mocha emits a "Root Suite" wrapper with no real tests — skip its own row.
+        const fileAttr = getAttr(suiteFragment, 'file');
+        const key = fileAttr || suiteName;
+
+        const entry = files.get(key) || { key, tests: 0, failures: 0, skipped: 0, time: 0 };
+
+        let caseMatch;
+        while ((caseMatch = caseRe.exec(suiteFragment)) !== null) {
+            const caseFragment = caseMatch[0];
+            const time = parseFloat(getAttr(caseFragment, 'time') || '0') || 0;
+            const failed = /<failure\b|<error\b/.test(caseFragment);
+            const skipped = /<skipped\b/.test(caseFragment);
+
+            entry.tests += 1;
+            entry.time += time;
+            totalTests += 1;
+            if (failed) {
+                entry.failures += 1;
+                totalFailures += 1;
+            }
+            if (skipped) {
+                entry.skipped += 1;
+                totalSkipped += 1;
+            }
+
+            tests.push({
+                name: decode(getAttr(caseFragment, 'name')) || '(unnamed)',
+                classname: decode(getAttr(caseFragment, 'classname')) || suiteName,
+                time,
+                failed,
+            });
+        }
+
+        // A <testsuite> may carry its own time attr; prefer the summed testcase time when we
+        // actually counted cases, otherwise fall back to the declared suite time.
+        if (entry.tests === 0) {
+            const declared = parseFloat(getAttr(suiteFragment, 'time') || '0') || 0;
+            entry.time = Math.max(entry.time, declared);
+        }
+        files.set(key, entry);
+    }
+
+    // Prefer the authoritative totals on the <testsuites> root when available.
+    const rootMatch = xml.match(/<testsuites\b[^>]*>/);
+    let rootTime = null;
+    if (rootMatch) {
+        rootTime = parseFloat(getAttr(rootMatch[0], 'time') || '');
+        const rootTests = parseInt(getAttr(rootMatch[0], 'tests') || '', 10);
+        const rootFailures = parseInt(getAttr(rootMatch[0], 'failures') || '', 10);
+        if (Number.isFinite(rootTests)) totalTests = rootTests;
+        if (Number.isFinite(rootFailures)) totalFailures = rootFailures;
+    }
+
+    const fileRows = [...files.values()].filter((f) => f.tests > 0);
+    const summedTime = fileRows.reduce((acc, f) => acc + f.time, 0);
+
+    return {
+        totalTests,
+        totalFailures,
+        totalSkipped,
+        totalTime: Number.isFinite(rootTime) && rootTime > 0 ? rootTime : summedTime,
+        fileRows,
+        tests,
+    };
+}
+
+function renderPhases(phase) {
+    out('## ⏱️ Pipeline phase timing');
+    out();
+    out('| Phase | Duration |');
+    out('| --- | ---: |');
+    const rows = [
+        ['Setup (node boot + federates)', phase.setupSeconds],
+        ['&nbsp;&nbsp;↳ mine initial blocks', phase.mineSeconds],
+        ['Tests', phase.testsSeconds],
+        ['Teardown', phase.teardownSeconds],
+    ];
+    for (const [label, value] of rows) {
+        if (value == null) continue;
+        out(`| ${label} | ${fmtDuration(value)} |`);
+    }
+    if (phase.totalSeconds != null) {
+        out(`| **Total (in-container)** | **${fmtDuration(phase.totalSeconds)}** |`);
+    }
+    out();
+}
+
+function main() {
+    if (!fs.existsSync(junitPath)) {
+        out('## ⏱️ Test timing summary');
+        out();
+        out(`> No JUnit report found at \`${junitPath}\` — nothing to summarize.`);
+        return;
+    }
+
+    // Optional per-phase timing (added by lib/phase-timing.js); render it first when present.
+    if (fs.existsSync(phasePath)) {
+        try {
+            renderPhases(JSON.parse(fs.readFileSync(phasePath, 'utf8')));
+        } catch {
+            out(`> Could not parse phase timing at \`${phasePath}\`.`);
+            out();
+        }
+    }
+
+    let report;
+    try {
+        report = parseJunit(fs.readFileSync(junitPath, 'utf8'));
+    } catch (err) {
+        out('## ⏱️ Test timing summary');
+        out();
+        out(`> Could not parse \`${junitPath}\`: ${err.message}`);
+        return;
+    }
+
+    out('## ⏱️ Test timing summary');
+    out();
+    out(
+        `**${report.totalTests}** tests · ` +
+            `**${report.totalFailures}** failed · ` +
+            `**${report.totalSkipped}** skipped · ` +
+            `total test time **${fmtDuration(report.totalTime)}**`
+    );
+    out();
+
+    const slowestFiles = [...report.fileRows].sort((a, b) => b.time - a.time);
+    if (slowestFiles.length > 0) {
+        out(`### Slowest test files (top ${Math.min(TOP_SLOWEST_FILES, slowestFiles.length)})`);
+        out();
+        out('| Test file / suite | Tests | Failed | Skipped | Time |');
+        out('| --- | ---: | ---: | ---: | ---: |');
+        for (const f of slowestFiles.slice(0, TOP_SLOWEST_FILES)) {
+            out(
+                `| \`${f.key}\` | ${f.tests} | ${f.failures} | ${f.skipped} | ${fmtDuration(f.time)} |`
+            );
+        }
+        out();
+    }
+
+    const slowestTests = [...report.tests].sort((a, b) => b.time - a.time);
+    if (slowestTests.length > 0) {
+        out(
+            `### Slowest individual tests (top ${Math.min(TOP_SLOWEST_TESTS, slowestTests.length)})`
+        );
+        out();
+        out('| Test | Time |');
+        out('| --- | ---: |');
+        for (const t of slowestTests.slice(0, TOP_SLOWEST_TESTS)) {
+            const flag = t.failed ? '❌ ' : '';
+            out(`| ${flag}${t.name} | ${fmtDuration(t.time)} |`);
+        }
+        out();
+    }
+
+    out(
+        `_Source: \`${path.basename(junitPath)}\` (uploaded as the \`rit-junit-report\` artifact)._`
+    );
+}
+
+main();

--- a/scripts/ci-timing-summary.js
+++ b/scripts/ci-timing-summary.js
@@ -6,7 +6,7 @@
  * Usage: node scripts/ci-timing-summary.js [path/to/junit.xml] [path/to/phase-timing.json]
  *
  * Writes Markdown to stdout; the workflow appends it to $GITHUB_STEP_SUMMARY. Designed to
- * never fail the job: missing/unparyable inputs produce a note, not a non-zero exit. The
+ * never fail the job: missing/unparsable inputs produce a note, not a non-zero exit. The
  * primary consumer of this breakdown is the sharding work (P2-01/P2-02), which needs
  * per-test-file durations to balance shards and to measure wall-clock against the baseline.
  */
@@ -14,17 +14,46 @@
 const fs = require('node:fs');
 const path = require('node:path');
 
-const junitPath = process.argv[2] || 'reports/junit.xml';
-const phasePath = process.argv[3] || 'reports/phase-timing.json';
+const junitArg = process.argv[2] || 'reports/junit.xml';
+const phaseArg = process.argv[3] || 'reports/phase-timing.json';
 
 // Number of rows to show in the "slowest" tables; the full data lives in the artifact.
 const TOP_SLOWEST_FILES = 30;
 const TOP_SLOWEST_TESTS = 15;
 
+// Paths come from argv, so validate them before any file-system access: resolve and confirm
+// they stay within the current directory or the CI workspace. This blocks path traversal via
+// crafted arguments (a resolved path that escapes every allowed root is refused).
+const ALLOWED_ROOTS = [process.cwd()];
+if (process.env.GITHUB_WORKSPACE) {
+    ALLOWED_ROOTS.push(path.resolve(process.env.GITHUB_WORKSPACE));
+}
+
+const resolveWithinAllowed = (p) => {
+    const resolved = path.resolve(p);
+    const ok = ALLOWED_ROOTS.some(
+        (root) => resolved === root || resolved.startsWith(root + path.sep)
+    );
+    if (!ok) {
+        throw new Error(`Refusing to access a path outside the workspace: ${p}`);
+    }
+    return resolved;
+};
+
+const safeExists = (p) => {
+    try {
+        return fs.existsSync(resolveWithinAllowed(p));
+    } catch {
+        return false;
+    }
+};
+
+const safeRead = (p) => fs.readFileSync(resolveWithinAllowed(p), 'utf8');
+
 const out = (line = '') => process.stdout.write(line + '\n');
 
 const fmtDuration = (seconds) => {
-    if (!isFinite(seconds) || seconds < 0) {
+    if (!Number.isFinite(seconds) || seconds < 0) {
         return '—';
     }
     const total = Math.round(seconds);
@@ -34,96 +63,106 @@ const fmtDuration = (seconds) => {
 };
 
 const getAttr = (fragment, name) => {
-    const match = fragment.match(new RegExp(`\\b${name}="([^"]*)"`));
+    const match = fragment.match(new RegExp(String.raw`\b${name}="([^"]*)"`));
     return match ? match[1] : null;
 };
 
 const decode = (str) =>
     (str || '')
-        .replace(/&lt;/g, '<')
-        .replace(/&gt;/g, '>')
-        .replace(/&quot;/g, '"')
-        .replace(/&apos;/g, "'")
-        .replace(/&amp;/g, '&');
+        .replaceAll('&lt;', '<')
+        .replaceAll('&gt;', '>')
+        .replaceAll('&quot;', '"')
+        .replaceAll('&apos;', "'")
+        .replaceAll('&amp;', '&');
+
+const CASE_RE = /<testcase\b[^>]*?(?:\/>|>[\s\S]*?<\/testcase>)/g;
+const SUITE_RE = /<testsuite\b[^>]*?(?:\/>|>[\s\S]*?<\/testsuite>)/g;
+
+// Fold a single <testcase> into its suite entry and the running totals.
+const addTestcase = (caseFragment, suiteName, entry, tests, totals) => {
+    const time = Number.parseFloat(getAttr(caseFragment, 'time') || '0') || 0;
+    const failed = /<failure\b|<error\b/.test(caseFragment);
+    const skipped = /<skipped\b/.test(caseFragment);
+
+    entry.tests += 1;
+    entry.time += time;
+    totals.tests += 1;
+    if (failed) {
+        entry.failures += 1;
+        totals.failures += 1;
+    }
+    if (skipped) {
+        entry.skipped += 1;
+        totals.skipped += 1;
+    }
+
+    tests.push({
+        name: decode(getAttr(caseFragment, 'name')) || '(unnamed)',
+        classname: decode(getAttr(caseFragment, 'classname')) || suiteName,
+        time,
+        failed,
+    });
+};
+
+// Aggregate one <testsuite> block into the files map and the tests/totals accumulators.
+const accumulateSuite = (suiteFragment, files, tests, totals) => {
+    const suiteName = decode(getAttr(suiteFragment, 'name')) || '(unnamed)';
+    const key = getAttr(suiteFragment, 'file') || suiteName;
+    const entry = files.get(key) || { key, tests: 0, failures: 0, skipped: 0, time: 0 };
+
+    for (const caseMatch of suiteFragment.matchAll(CASE_RE)) {
+        addTestcase(caseMatch[0], suiteName, entry, tests, totals);
+    }
+
+    // A <testsuite> may carry its own time attr; prefer the summed testcase time when we
+    // actually counted cases, otherwise fall back to the declared suite time.
+    if (entry.tests === 0) {
+        const declared = Number.parseFloat(getAttr(suiteFragment, 'time') || '0') || 0;
+        entry.time = Math.max(entry.time, declared);
+    }
+    files.set(key, entry);
+};
+
+// Prefer the authoritative totals on the <testsuites> root when available, overriding the
+// summed counts. Returns the root-declared total time, or null when absent.
+const applyRootTotals = (xml, totals) => {
+    const rootMatch = xml.match(/<testsuites\b[^>]*>/);
+    if (!rootMatch) {
+        return null;
+    }
+    const rootTests = Number.parseInt(getAttr(rootMatch[0], 'tests') || '', 10);
+    const rootFailures = Number.parseInt(getAttr(rootMatch[0], 'failures') || '', 10);
+    if (Number.isFinite(rootTests)) {
+        totals.tests = rootTests;
+    }
+    if (Number.isFinite(rootFailures)) {
+        totals.failures = rootFailures;
+    }
+    const rootTime = Number.parseFloat(getAttr(rootMatch[0], 'time') || '');
+    return Number.isFinite(rootTime) && rootTime > 0 ? rootTime : null;
+};
 
 // Parse the mocha-junit-reporter output. Its shape is a flat list of <testsuite> elements
 // under a single <testsuites> root, each holding <testcase> children — so attribute-level
 // regex parsing is sufficient here (no nesting to track).
 function parseJunit(xml) {
-    const suiteRe = /<testsuite\b[^>]*?(?:\/>|>[\s\S]*?<\/testsuite>)/g;
-    const caseRe = /<testcase\b[^>]*?(?:\/>|>[\s\S]*?<\/testcase>)/g;
-
     const files = new Map(); // key: file or suite name -> aggregated stats
     const tests = []; // individual testcases, for the "slowest tests" table
-    let totalTests = 0;
-    let totalFailures = 0;
-    let totalSkipped = 0;
+    const totals = { tests: 0, failures: 0, skipped: 0 };
 
-    let suiteMatch;
-    while ((suiteMatch = suiteRe.exec(xml)) !== null) {
-        const suiteFragment = suiteMatch[0];
-        const suiteName = decode(getAttr(suiteFragment, 'name')) || '(unnamed)';
-        // mocha emits a "Root Suite" wrapper with no real tests — skip its own row.
-        const fileAttr = getAttr(suiteFragment, 'file');
-        const key = fileAttr || suiteName;
-
-        const entry = files.get(key) || { key, tests: 0, failures: 0, skipped: 0, time: 0 };
-
-        let caseMatch;
-        while ((caseMatch = caseRe.exec(suiteFragment)) !== null) {
-            const caseFragment = caseMatch[0];
-            const time = parseFloat(getAttr(caseFragment, 'time') || '0') || 0;
-            const failed = /<failure\b|<error\b/.test(caseFragment);
-            const skipped = /<skipped\b/.test(caseFragment);
-
-            entry.tests += 1;
-            entry.time += time;
-            totalTests += 1;
-            if (failed) {
-                entry.failures += 1;
-                totalFailures += 1;
-            }
-            if (skipped) {
-                entry.skipped += 1;
-                totalSkipped += 1;
-            }
-
-            tests.push({
-                name: decode(getAttr(caseFragment, 'name')) || '(unnamed)',
-                classname: decode(getAttr(caseFragment, 'classname')) || suiteName,
-                time,
-                failed,
-            });
-        }
-
-        // A <testsuite> may carry its own time attr; prefer the summed testcase time when we
-        // actually counted cases, otherwise fall back to the declared suite time.
-        if (entry.tests === 0) {
-            const declared = parseFloat(getAttr(suiteFragment, 'time') || '0') || 0;
-            entry.time = Math.max(entry.time, declared);
-        }
-        files.set(key, entry);
+    for (const suiteMatch of xml.matchAll(SUITE_RE)) {
+        accumulateSuite(suiteMatch[0], files, tests, totals);
     }
 
-    // Prefer the authoritative totals on the <testsuites> root when available.
-    const rootMatch = xml.match(/<testsuites\b[^>]*>/);
-    let rootTime = null;
-    if (rootMatch) {
-        rootTime = parseFloat(getAttr(rootMatch[0], 'time') || '');
-        const rootTests = parseInt(getAttr(rootMatch[0], 'tests') || '', 10);
-        const rootFailures = parseInt(getAttr(rootMatch[0], 'failures') || '', 10);
-        if (Number.isFinite(rootTests)) totalTests = rootTests;
-        if (Number.isFinite(rootFailures)) totalFailures = rootFailures;
-    }
-
+    const rootTime = applyRootTotals(xml, totals);
     const fileRows = [...files.values()].filter((f) => f.tests > 0);
     const summedTime = fileRows.reduce((acc, f) => acc + f.time, 0);
 
     return {
-        totalTests,
-        totalFailures,
-        totalSkipped,
-        totalTime: Number.isFinite(rootTime) && rootTime > 0 ? rootTime : summedTime,
+        totalTests: totals.tests,
+        totalFailures: totals.failures,
+        totalSkipped: totals.skipped,
+        totalTime: rootTime != null ? rootTime : summedTime,
         fileRows,
         tests,
     };
@@ -150,31 +189,64 @@ function renderPhases(phase) {
     out();
 }
 
+function renderSlowestFiles(fileRows) {
+    const slowest = [...fileRows].sort((a, b) => b.time - a.time);
+    if (slowest.length === 0) {
+        return;
+    }
+    out(`### Slowest test files (top ${Math.min(TOP_SLOWEST_FILES, slowest.length)})`);
+    out();
+    out('| Test file / suite | Tests | Failed | Skipped | Time |');
+    out('| --- | ---: | ---: | ---: | ---: |');
+    for (const f of slowest.slice(0, TOP_SLOWEST_FILES)) {
+        out(
+            `| \`${f.key}\` | ${f.tests} | ${f.failures} | ${f.skipped} | ${fmtDuration(f.time)} |`
+        );
+    }
+    out();
+}
+
+function renderSlowestTests(tests) {
+    const slowest = [...tests].sort((a, b) => b.time - a.time);
+    if (slowest.length === 0) {
+        return;
+    }
+    out(`### Slowest individual tests (top ${Math.min(TOP_SLOWEST_TESTS, slowest.length)})`);
+    out();
+    out('| Test | Time |');
+    out('| --- | ---: |');
+    for (const t of slowest.slice(0, TOP_SLOWEST_TESTS)) {
+        const flag = t.failed ? '❌ ' : '';
+        out(`| ${flag}${t.name} | ${fmtDuration(t.time)} |`);
+    }
+    out();
+}
+
 function main() {
-    if (!fs.existsSync(junitPath)) {
+    if (!safeExists(junitArg)) {
         out('## ⏱️ Test timing summary');
         out();
-        out(`> No JUnit report found at \`${junitPath}\` — nothing to summarize.`);
+        out(`> No JUnit report found at \`${junitArg}\` — nothing to summarize.`);
         return;
     }
 
     // Optional per-phase timing (added by lib/phase-timing.js); render it first when present.
-    if (fs.existsSync(phasePath)) {
+    if (safeExists(phaseArg)) {
         try {
-            renderPhases(JSON.parse(fs.readFileSync(phasePath, 'utf8')));
+            renderPhases(JSON.parse(safeRead(phaseArg)));
         } catch {
-            out(`> Could not parse phase timing at \`${phasePath}\`.`);
+            out(`> Could not parse phase timing at \`${phaseArg}\`.`);
             out();
         }
     }
 
     let report;
     try {
-        report = parseJunit(fs.readFileSync(junitPath, 'utf8'));
+        report = parseJunit(safeRead(junitArg));
     } catch (err) {
         out('## ⏱️ Test timing summary');
         out();
-        out(`> Could not parse \`${junitPath}\`: ${err.message}`);
+        out(`> Could not parse \`${junitArg}\`: ${err.message}`);
         return;
     }
 
@@ -188,37 +260,11 @@ function main() {
     );
     out();
 
-    const slowestFiles = [...report.fileRows].sort((a, b) => b.time - a.time);
-    if (slowestFiles.length > 0) {
-        out(`### Slowest test files (top ${Math.min(TOP_SLOWEST_FILES, slowestFiles.length)})`);
-        out();
-        out('| Test file / suite | Tests | Failed | Skipped | Time |');
-        out('| --- | ---: | ---: | ---: | ---: |');
-        for (const f of slowestFiles.slice(0, TOP_SLOWEST_FILES)) {
-            out(
-                `| \`${f.key}\` | ${f.tests} | ${f.failures} | ${f.skipped} | ${fmtDuration(f.time)} |`
-            );
-        }
-        out();
-    }
-
-    const slowestTests = [...report.tests].sort((a, b) => b.time - a.time);
-    if (slowestTests.length > 0) {
-        out(
-            `### Slowest individual tests (top ${Math.min(TOP_SLOWEST_TESTS, slowestTests.length)})`
-        );
-        out();
-        out('| Test | Time |');
-        out('| --- | ---: |');
-        for (const t of slowestTests.slice(0, TOP_SLOWEST_TESTS)) {
-            const flag = t.failed ? '❌ ' : '';
-            out(`| ${flag}${t.name} | ${fmtDuration(t.time)} |`);
-        }
-        out();
-    }
+    renderSlowestFiles(report.fileRows);
+    renderSlowestTests(report.tests);
 
     out(
-        `_Source: \`${path.basename(junitPath)}\` (uploaded as the \`rit-junit-report\` artifact)._`
+        `_Source: \`${path.basename(junitArg)}\` (uploaded as the \`rit-junit-report\` artifact)._`
     );
 }
 

--- a/scripts/ci-timing-summary.js
+++ b/scripts/ci-timing-summary.js
@@ -21,34 +21,27 @@ const phaseArg = process.argv[3] || 'reports/phase-timing.json';
 const TOP_SLOWEST_FILES = 30;
 const TOP_SLOWEST_TESTS = 15;
 
-// Paths come from argv, so validate them before any file-system access: resolve and confirm
-// they stay within the current directory or the CI workspace. This blocks path traversal via
-// crafted arguments (a resolved path that escapes every allowed root is refused).
-const ALLOWED_ROOTS = [process.cwd()];
-if (process.env.GITHUB_WORKSPACE) {
-    ALLOWED_ROOTS.push(path.resolve(process.env.GITHUB_WORKSPACE));
-}
-
-const resolveWithinAllowed = (p) => {
-    const resolved = path.resolve(p);
-    const ok = ALLOWED_ROOTS.some(
-        (root) => resolved === root || resolved.startsWith(root + path.sep)
-    );
-    if (!ok) {
-        throw new Error(`Refusing to access a path outside the workspace: ${p}`);
-    }
-    return resolved;
-};
+// Paths come from argv, so guard them before any file-system access: resolve against the
+// working directory (which is GITHUB_WORKSPACE in CI, where the reports live) and confirm the
+// canonical path stays inside it. The check is inlined at each use so a crafted argument that
+// escapes the base is refused before it ever reaches the file system.
+const BASE_DIR = path.resolve(process.cwd());
 
 const safeExists = (p) => {
-    try {
-        return fs.existsSync(resolveWithinAllowed(p));
-    } catch {
+    const resolved = path.resolve(BASE_DIR, p);
+    if (resolved !== BASE_DIR && !resolved.startsWith(BASE_DIR + path.sep)) {
         return false;
     }
+    return fs.existsSync(resolved);
 };
 
-const safeRead = (p) => fs.readFileSync(resolveWithinAllowed(p), 'utf8');
+const safeRead = (p) => {
+    const resolved = path.resolve(BASE_DIR, p);
+    if (resolved !== BASE_DIR && !resolved.startsWith(BASE_DIR + path.sep)) {
+        throw new Error(`Refusing to access a path outside the workspace: ${p}`);
+    }
+    return fs.readFileSync(resolved, 'utf8');
+};
 
 const out = (line = '') => process.stdout.write(line + '\n');
 

--- a/scripts/ci-timing-summary.js
+++ b/scripts/ci-timing-summary.js
@@ -23,16 +23,22 @@ const TOP_SLOWEST_TESTS = 15;
 
 // Paths come from argv, so guard them before any file-system access: resolve against the
 // working directory (which is GITHUB_WORKSPACE in CI, where the reports live) and confirm the
-// canonical path stays inside it. The check is inlined at each use so a crafted argument that
-// escapes the base is refused before it ever reaches the file system.
-const BASE_DIR = path.resolve(process.cwd());
+// canonical path stays inside it. The check is kept inline at each use so a crafted argument
+// that escapes the base is refused before it ever reaches the file system. realpathSync
+// additionally blocks a symlink under the (container-written) reports dir from pointing
+// outside the base — BASE_DIR is itself realpath'd so the comparison holds on symlinked roots.
+const BASE_DIR = fs.realpathSync(path.resolve(process.cwd()));
 
 const safeExists = (p) => {
     const resolved = path.resolve(BASE_DIR, p);
     if (resolved !== BASE_DIR && !resolved.startsWith(BASE_DIR + path.sep)) {
         return false;
     }
-    return fs.existsSync(resolved);
+    if (!fs.existsSync(resolved)) {
+        return false;
+    }
+    const real = fs.realpathSync(resolved);
+    return real === BASE_DIR || real.startsWith(BASE_DIR + path.sep);
 };
 
 const safeRead = (p) => {
@@ -40,10 +46,21 @@ const safeRead = (p) => {
     if (resolved !== BASE_DIR && !resolved.startsWith(BASE_DIR + path.sep)) {
         throw new Error(`Refusing to access a path outside the workspace: ${p}`);
     }
-    return fs.readFileSync(resolved, 'utf8');
+    const real = fs.realpathSync(resolved);
+    if (real !== BASE_DIR && !real.startsWith(BASE_DIR + path.sep)) {
+        throw new Error(`Refusing to follow a symlink outside the workspace: ${p}`);
+    }
+    return fs.readFileSync(real, 'utf8');
 };
 
 const out = (line = '') => process.stdout.write(line + '\n');
+
+// Test/suite names are arbitrary strings; a literal `|` or a newline would break the Markdown
+// table, so neutralize both before writing a cell.
+const escapeCell = (str) =>
+    String(str)
+        .replaceAll('|', '\\|')
+        .replaceAll(/[\r\n]+/g, ' ');
 
 const fmtDuration = (seconds) => {
     if (!Number.isFinite(seconds) || seconds < 0) {
@@ -131,6 +148,10 @@ const applyRootTotals = (xml, totals) => {
     if (Number.isFinite(rootFailures)) {
         totals.failures = rootFailures;
     }
+    const rootSkipped = Number.parseInt(getAttr(rootMatch[0], 'skipped') || '', 10);
+    if (Number.isFinite(rootSkipped)) {
+        totals.skipped = rootSkipped;
+    }
     const rootTime = Number.parseFloat(getAttr(rootMatch[0], 'time') || '');
     return Number.isFinite(rootTime) && rootTime > 0 ? rootTime : null;
 };
@@ -167,7 +188,7 @@ function renderPhases(phase) {
     out('| Phase | Duration |');
     out('| --- | ---: |');
     const rows = [
-        ['Setup (node boot + federates)', phase.setupSeconds],
+        ['Setup (bitcoind + federate nodes)', phase.setupSeconds],
         ['&nbsp;&nbsp;↳ mine initial blocks', phase.mineSeconds],
         ['Tests', phase.testsSeconds],
         ['Teardown', phase.teardownSeconds],
@@ -193,7 +214,7 @@ function renderSlowestFiles(fileRows) {
     out('| --- | ---: | ---: | ---: | ---: |');
     for (const f of slowest.slice(0, TOP_SLOWEST_FILES)) {
         out(
-            `| \`${f.key}\` | ${f.tests} | ${f.failures} | ${f.skipped} | ${fmtDuration(f.time)} |`
+            `| \`${escapeCell(f.key)}\` | ${f.tests} | ${f.failures} | ${f.skipped} | ${fmtDuration(f.time)} |`
         );
     }
     out();
@@ -210,7 +231,7 @@ function renderSlowestTests(tests) {
     out('| --- | ---: |');
     for (const t of slowest.slice(0, TOP_SLOWEST_TESTS)) {
         const flag = t.failed ? '❌ ' : '';
-        out(`| ${flag}${t.name} | ${fmtDuration(t.time)} |`);
+        out(`| ${flag}${escapeCell(t.name)} | ${fmtDuration(t.time)} |`);
     }
     out();
 }

--- a/scripts/ci-timing-summary.js
+++ b/scripts/ci-timing-summary.js
@@ -245,7 +245,7 @@ function renderSlowestTests(tests) {
     out('| --- | ---: |');
     for (const t of slowest.slice(0, TOP_SLOWEST_TESTS)) {
         const flag = t.failed ? '❌ ' : '';
-        out(`| ${flag}${escapeCell(t.name)} | ${fmtDuration(t.time)} |`);
+        out(`| ${flag}\`${escapeCell(t.name)}\` | ${fmtDuration(t.time)} |`);
     }
     out();
 }

--- a/scripts/ci-timing-summary.js
+++ b/scripts/ci-timing-summary.js
@@ -27,18 +27,30 @@ const TOP_SLOWEST_TESTS = 15;
 // that escapes the base is refused before it ever reaches the file system. realpathSync
 // additionally blocks a symlink under the (container-written) reports dir from pointing
 // outside the base — BASE_DIR is itself realpath'd so the comparison holds on symlinked roots.
-const BASE_DIR = fs.realpathSync(path.resolve(process.cwd()));
+// realpathSync can throw (permissions, broken symlink); fall back to the plain resolved cwd so
+// module load never crashes the summary step.
+let BASE_DIR;
+try {
+    BASE_DIR = fs.realpathSync(path.resolve(process.cwd()));
+} catch {
+    BASE_DIR = path.resolve(process.cwd());
+}
 
 const safeExists = (p) => {
-    const resolved = path.resolve(BASE_DIR, p);
-    if (resolved !== BASE_DIR && !resolved.startsWith(BASE_DIR + path.sep)) {
+    try {
+        const resolved = path.resolve(BASE_DIR, p);
+        if (resolved !== BASE_DIR && !resolved.startsWith(BASE_DIR + path.sep)) {
+            return false;
+        }
+        if (!fs.existsSync(resolved)) {
+            return false;
+        }
+        const real = fs.realpathSync(resolved);
+        return real === BASE_DIR || real.startsWith(BASE_DIR + path.sep);
+    } catch {
+        // Never let a file-system probe fail the job — treat as "not present".
         return false;
     }
-    if (!fs.existsSync(resolved)) {
-        return false;
-    }
-    const real = fs.realpathSync(resolved);
-    return real === BASE_DIR || real.startsWith(BASE_DIR + path.sep);
 };
 
 const safeRead = (p) => {
@@ -55,11 +67,13 @@ const safeRead = (p) => {
 
 const out = (line = '') => process.stdout.write(line + '\n');
 
-// Test/suite names are arbitrary strings; a literal `|` or a newline would break the Markdown
-// table, so neutralize both before writing a cell.
+// Test/suite names are arbitrary strings; a literal `|`, a backtick (which would break a cell
+// wrapped in an inline-code span), or a newline would break the Markdown table, so neutralize
+// them before writing a cell.
 const escapeCell = (str) =>
     String(str)
         .replaceAll('|', '\\|')
+        .replaceAll('`', "'")
         .replaceAll(/[\r\n]+/g, ' ');
 
 const fmtDuration = (seconds) => {

--- a/test.js
+++ b/test.js
@@ -199,9 +199,14 @@ before(async () => {
             );
             if (initConfig.mineInitialBitcoin) {
                 phaseTiming.mark('mineStart');
-                const btcTxHelper = getBtcClient();
-                await btcTxHelper.mine(INITIAL_BTC_BLOCKS);
-                phaseTiming.mark('mineEnd');
+                try {
+                    const btcTxHelper = getBtcClient();
+                    await btcTxHelper.mine(INITIAL_BTC_BLOCKS);
+                } finally {
+                    // Record mineEnd even if mining throws, so the phase breakdown stays
+                    // meaningful on the failing runs where it is most useful.
+                    phaseTiming.mark('mineEnd');
+                }
             }
             process.stdout.write(
                 `${BITCOIND_OUTPUT} generated initial ${INITIAL_BTC_BLOCKS} blocks\n`
@@ -225,9 +230,14 @@ before(async () => {
         };
         if (initConfig.mineInitialBitcoin) {
             phaseTiming.mark('mineStart');
-            const btcTxHelper = getBtcClient();
-            await btcTxHelper.mine(INITIAL_BTC_BLOCKS);
-            phaseTiming.mark('mineEnd');
+            try {
+                const btcTxHelper = getBtcClient();
+                await btcTxHelper.mine(INITIAL_BTC_BLOCKS);
+            } finally {
+                // Record mineEnd even if mining throws, so the phase breakdown stays
+                // meaningful on the failing runs where it is most useful.
+                phaseTiming.mark('mineEnd');
+            }
         }
     }
 

--- a/test.js
+++ b/test.js
@@ -24,6 +24,11 @@ if (global.describe == null || global.it == null) {
     process.exit(1);
 }
 
+// Per-phase timing (setup/mine/tests/teardown) for the CI run summary. Requiring this
+// self-registers root hooks; the mine() calls below are bracketed with its marks. Diagnostic
+// only — it never affects the run.
+const phaseTiming = require('./lib/phase-timing');
+
 // Load the configuration, regtest by default
 const configFileName = process.env.CONFIG_FILE_PATH || './config/regtest-all-keyfiles';
 
@@ -193,8 +198,10 @@ before(async () => {
                 `${BITCOIND_OUTPUT} running on port ${Runners.btcRunner.ports.btc}, rpc port ${Runners.btcRunner.ports.rpc}, directory ${Runners.btcRunner.getDataDir()} (PID: ${Runners.btcRunner.getPid()})\n`
             );
             if (initConfig.mineInitialBitcoin) {
+                phaseTiming.mark('mineStart');
                 const btcTxHelper = getBtcClient();
                 await btcTxHelper.mine(INITIAL_BTC_BLOCKS);
+                phaseTiming.mark('mineEnd');
             }
             process.stdout.write(
                 `${BITCOIND_OUTPUT} generated initial ${INITIAL_BTC_BLOCKS} blocks\n`
@@ -217,8 +224,10 @@ before(async () => {
             network: btcNetworks.regtest,
         };
         if (initConfig.mineInitialBitcoin) {
+            phaseTiming.mark('mineStart');
             const btcTxHelper = getBtcClient();
             await btcTxHelper.mine(INITIAL_BTC_BLOCKS);
+            phaseTiming.mark('mineEnd');
         }
     }
 


### PR DESCRIPTION
This pull request introduces improved test timing instrumentation and reporting for the CI pipeline. It adds per-phase timing measurement to the test suite, generates a detailed Markdown timing summary in the GitHub Actions run summary, and surfaces test failures as annotated PR checks. These changes make it easier to diagnose slow phases and failing tests, and provide the necessary data for future test sharding work.

**CI workflow and reporting improvements:**

* Added job-level `permissions` to the Rootstock Integration Tests job in `.github/workflows/ci.yml` to allow publishing test failure annotations as PR checks.
* Added steps in `.github/workflows/ci.yml` to:
  - Render a Markdown test timing summary (including per-phase timing when available) into the run summary, even on failures.
  - Publish test failures as PR check annotations using `dorny/test-reporter`, with logic to avoid failing the job for missing reports or fork PRs.

**Test timing instrumentation:**

* Added `lib/phase-timing.js` to record per-phase timing (setup, mining, tests, teardown) during the test suite run, writing results to `reports/phase-timing.json`. This module is designed to be safe and not interfere with test execution.
* Updated `test.js` to require `lib/phase-timing.js` at startup and to mark the start and end of the mining phase, enabling accurate breakdown of time spent in each phase. [[1]](diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60R27-R31) [[2]](diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60R201-R204) [[3]](diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60R227-R230)

**Test timing summary rendering:**

* Added `scripts/ci-timing-summary.js` to parse the JUnit XML report and optional per-phase timing file, emitting a Markdown summary table of total test counts, failures, skipped tests, total time, slowest test files, and slowest individual tests for the GitHub Actions run summary.