### PR TITLE
P2 02 matrix sharding by state group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,25 +37,28 @@ concurrency:
 env:
   TEST_TAG:  ${{ github.event.repository.name }}/rit:test
   LATEST_TAG: ghcr.io/rsksmart/${{ github.event.repository.name }}/rit
-  # TEST_SUITE is exported by the set-branch-variables composite action: PRs get the short suite,
-  # auto-escalated to full when the PR touches full-suite-affecting paths (tests/**/extra/,
-  # lib/tests/, lib/assertions/, test.js, config/) and overridable with a `test-suite:<suite>`
-  # tag in the PR description (like in rskj/powpeg-node); pushes to main and manual runs
-  # default to the full (long) suite.
+  # TEST_SUITE is resolved by the set-branch-variables composite action in the prepare job: PRs
+  # get the short suite, auto-escalated to full when the PR touches full-suite-affecting paths
+  # (tests/**/extra/, lib/tests/, lib/assertions/, test.js, config/) and overridable with a
+  # `test-suite:<suite>` tag in the PR description; pushes to main and manual runs default to full.
 
 jobs:
-  test-container-action:
-    name: Rootstock Integration Tests
+  # ---------------------------------------------------------------------------------------------
+  # P2-02 sharding: build the image + resolve branch vars once, then emit the shard matrix.
+  # The full suite fans out into the P2-01 state-groups (each shard boots its own bitcoind +
+  # federate cluster, runs the 00_sync bootstrap, then its group via INCLUDE_CASES). The short
+  # suite (extra/ skipped) stays a single shard — no fan-out overhead for the fast PR subset.
+  # ---------------------------------------------------------------------------------------------
+  prepare:
+    name: Prepare (build image + shard matrix)
     runs-on: ubuntu-latest
-    timeout-minutes: 60
-    # checks: write lets the test-reporter publish failures as a PR check with annotations.
-    # (Job-level perms replace the top-level default, so contents: read is re-declared here.)
-    # Note: PRs from forks always get a read-only token, so the annotation check is skipped
-    # for them — the step is set to not fail the job in that case.
-    permissions:
-      contents: read
-      checks: write
-
+    timeout-minutes: 30
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      rskj_branch: ${{ steps.vars.outputs.rskj_branch }}
+      powpeg_branch: ${{ steps.vars.outputs.powpeg_branch }}
+      rit_branch: ${{ steps.vars.outputs.rit_branch }}
+      test_suite: ${{ steps.vars.outputs.test_suite }}
     steps:
       - name: Checkout
         id: checkout
@@ -69,26 +72,213 @@ jobs:
           driver-opts: network=host
           platforms: linux/amd64
 
+      # Build once here to populate the gha layer cache (mode=max). Each shard then replays the
+      # cache instead of racing to build the same image N times in parallel.
+      - name: Warm Docker layer cache
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: container-action/
+          tags: ${{ env.TEST_TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Set Branch Variables
+        uses: ./.github/actions/set-branch-variables
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # set-branch-variables writes to GITHUB_ENV (job-scoped); re-export as job outputs so the
+      # shard and aggregate jobs can consume them.
+      - name: Export branch variables
+        id: vars
+        run: |
+          {
+            echo "rskj_branch=$RSKJ_BRANCH"
+            echo "powpeg_branch=$POWPEG_BRANCH"
+            echo "rit_branch=$RIT_BRANCH"
+            echo "test_suite=$TEST_SUITE"
+          } >> "$GITHUB_OUTPUT"
+
+      # Shard membership follows the P2-01 state-dependency map. Every shard's INCLUDE_CASES
+      # begins with 00_sync so the mandatory bootstrap runs on its own cluster before its group.
+      - name: Compute shard matrix
+        id: set-matrix
+        run: |
+          if [ "$TEST_SUITE" = "short" ]; then
+            # The short suite skips extra/ entirely (only 3 files run); no fan-out benefit.
+            matrix='{"include":[{"name":"short","cases":""}]}'
+          else
+            matrix='{"include":[
+              {"name":"federation","cases":"00_sync,01_powpeg/01-change-federation,01_powpeg/extra/04-change-federation-full"},
+              {"name":"2wp","cases":"00_sync,01_powpeg/02-2wp,01_powpeg/extra/05-2wp-full"},
+              {"name":"bridge-queries","cases":"00_sync,01_powpeg/extra/03,01_powpeg/extra/06,01_powpeg/extra/08,01_powpeg/extra/09,01_powpeg/extra/12,01_powpeg/extra/13,01_powpeg/extra/14,01_powpeg/extra/15"},
+              {"name":"param-mutators","cases":"00_sync,01_powpeg/extra/01,01_powpeg/extra/02,01_powpeg/extra/07,01_powpeg/extra/10,01_powpeg/extra/11"}
+            ]}'
+          fi
+          # Collapse to a single line so it is valid as a matrix expression.
+          matrix=$(echo "$matrix" | tr -d '\n' | tr -s ' ')
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  # ---------------------------------------------------------------------------------------------
+  # One job per shard. fail-fast:false so a failing shard doesn't cancel the others; the
+  # aggregate job below turns the set of shard results into one required status.
+  # ---------------------------------------------------------------------------------------------
+  test-container-action:
+    name: RIT (${{ matrix.name }})
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # checks: write lets the test-reporter publish failures as a PR check with annotations.
+    # Note: PRs from forks always get a read-only token, so the annotation check is skipped for
+    # them — the step is set to not fail the job in that case.
+    permissions:
+      contents: read
+      checks: write
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Docker BuildX
+        id: setup-buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          install: true
+          driver-opts: network=host
+          platforms: linux/amd64
+
+      # Pure cache replay of the image built in prepare (cache-to mode=max there).
       - name: Build and export locally Docker
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: container-action/
           load: true
           tags: ${{ env.TEST_TAG }}
-          # mode=max caches every layer so the publish job's rebuild is a pure cache replay.
           cache-from: type=gha
-          cache-to: type=gha,mode=max
 
-      # Call the composite action to set branch variables
-      - name: Set Branch Variables
-        uses: ./.github/actions/set-branch-variables
+      - name: Run Rootstock Integration Tests
+        id: test-container
+        env:
+          INPUT_RIT_LOG_LEVEL: info
+        run: |
+          mkdir -p "${{ github.workspace }}/reports"
+          docker run \
+            --env GITHUB_OUTPUT="/github-output"  \
+            --env GITHUB_WORKSPACE="/github/workspace"  \
+            --env INPUT_RSKJ_BRANCH="${{ needs.prepare.outputs.rskj_branch }}"  \
+            --env INPUT_POWPEG_NODE_BRANCH="${{ needs.prepare.outputs.powpeg_branch }}"  \
+            --env INPUT_RIT_BRANCH="${{ needs.prepare.outputs.rit_branch }}"  \
+            --env INPUT_RIT_LOG_LEVEL="${{ env.INPUT_RIT_LOG_LEVEL }}" \
+            --env INPUT_TEST_SUITE="${{ needs.prepare.outputs.test_suite }}" \
+            --env INPUT_INCLUDE_CASES="${{ matrix.cases }}" \
+            -v "$GITHUB_OUTPUT:/github-output"  \
+            -v "${{ github.workspace }}/reports:/github/workspace/reports"  \
+            --rm ${{ env.TEST_TAG }}
+
+      - name: Upload JUnit report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          name: rit-junit-report-${{ matrix.name }}
+          path: reports/junit.xml
+          if-no-files-found: warn
+
+      # Render this shard's JUnit report (and per-phase timing, when present) into the run summary.
+      # always() so the breakdown is produced on failing runs too; the script never exits non-zero,
+      # so it cannot turn a passing run red.
+      - name: Test timing summary
+        if: always()
+        run: |
+          echo "## 🧩 Shard: ${{ matrix.name }}" >> "$GITHUB_STEP_SUMMARY"
+          node scripts/ci-timing-summary.js reports/junit.xml reports/phase-timing.json >> "$GITHUB_STEP_SUMMARY"
+
+      # Surface failing tests as a PR check with per-test annotations instead of only in the raw
+      # log. always() so failures are still reported. Skipped for fork PRs, whose read-only token
+      # can't create the check; fail-on-error/fail-on-empty stay false as a guard for empty reports.
+      - name: Publish test report (PR annotations)
+        if: >-
+          always() &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository)
+        uses: dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3 # v3.0.0
+        with:
+          name: RIT Test Results (${{ matrix.name }})
+          path: reports/junit.xml
+          reporter: java-junit
+          fail-on-error: false
+          fail-on-empty: false
+
+  # ---------------------------------------------------------------------------------------------
+  # Single required status for the whole run: green only if every shard passed. Also owns the
+  # (one) Slack notification, so a sharded run still produces exactly one message.
+  # ---------------------------------------------------------------------------------------------
+  aggregate:
+    name: Aggregate & gate
+    needs: [prepare, test-container-action]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # actions: read lets download-artifact collect every shard's report for the consolidated view.
+    permissions:
+      contents: read
+      actions: read
+    env:
+      RSKJ_BRANCH: ${{ needs.prepare.outputs.rskj_branch }}
+      POWPEG_BRANCH: ${{ needs.prepare.outputs.powpeg_branch }}
+      RIT_BRANCH: ${{ needs.prepare.outputs.rit_branch }}
+    steps:
+      # Checkout so the timing script is available, then pull every shard's JUnit report and render
+      # ONE consolidated timing table for the whole run (each shard also writes its own summary).
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Download all shard JUnit reports
+        if: always()
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: rit-junit-report-*
+          path: shard-reports
+
+      - name: Consolidated timing summary (all shards)
+        if: always()
+        continue-on-error: true
+        run: |
+          echo "# ⏱️ Consolidated test timing (all shards)" >> "$GITHUB_STEP_SUMMARY"
+          shopt -s nullglob
+          found=0
+          for report in shard-reports/*/junit.xml; do
+            found=1
+            shard_name=$(basename "$(dirname "$report")" | sed 's/^rit-junit-report-//')
+            echo "## 🧩 Shard: ${shard_name}" >> "$GITHUB_STEP_SUMMARY"
+            # The timing script never exits non-zero, but guard anyway so one bad report can't fail
+            # the consolidation (it is a reporting nicety, not a gate).
+            node scripts/ci-timing-summary.js "$report" >> "$GITHUB_STEP_SUMMARY" || true
+          done
+          if [ "$found" = "0" ]; then
+            echo "> No shard JUnit reports were downloaded." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Gate on build + shard results
+        run: |
+          echo "prepare (build + matrix): ${{ needs.prepare.result }}"
+          echo "test shards (aggregate):  ${{ needs.test-container-action.result }}"
+          if [ "${{ needs.prepare.result }}" != "success" ]; then
+            echo "::error::The build/prepare job did not succeed."
+            exit 1
+          fi
+          if [ "${{ needs.test-container-action.result }}" != "success" ]; then
+            echo "::error::One or more test shards did not pass."
+            exit 1
+          fi
+          echo "Build and all shards passed."
 
       - name: Set Build URL
         id: set-build-url
-        # always() so the failure notification still gets a valid BUILD_URL when an earlier
-        # step (e.g. the Docker build) fails.
         if: always()
         run: |
           BUILD_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -96,8 +286,6 @@ jobs:
 
       - name: Set Notification Context
         id: set-notification-context
-        # always() so the failure notification still gets its title/URL/label when an earlier
-        # step fails; this step only reads the github context, never earlier steps' results.
         if: always()
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
@@ -151,67 +339,9 @@ jobs:
           write_env NOTIFICATION_URL "$NOTIFICATION_URL"
           write_env NOTIFICATION_ACTION_LABEL "$NOTIFICATION_ACTION_LABEL"
 
-      - name: Run Rootstock Integration Tests
-        id: test-container
-        env:
-          INPUT_RSKJ_BRANCH: ${{ env.RSKJ_BRANCH }}
-          INPUT_POWPEG_NODE_BRANCH: ${{ env.POWPEG_BRANCH }}
-          INPUT_RIT_BRANCH: ${{ env.RIT_BRANCH }}
-          INPUT_RIT_LOG_LEVEL: info
-        run: |
-          mkdir -p "${{ github.workspace }}/reports"
-          docker run \
-            --env GITHUB_OUTPUT="/github-output"  \
-            --env GITHUB_WORKSPACE="/github/workspace"  \
-            --env INPUT_RSKJ_BRANCH="${{ env.RSKJ_BRANCH }}"  \
-            --env INPUT_POWPEG_NODE_BRANCH="${{ env.POWPEG_BRANCH }}"  \
-            --env INPUT_RIT_BRANCH="${{ env.RIT_BRANCH }}"  \
-            --env INPUT_RIT_LOG_LEVEL="${{ env.INPUT_RIT_LOG_LEVEL }}" \
-            --env INPUT_TEST_SUITE="${{ env.TEST_SUITE }}" \
-            -v "$GITHUB_OUTPUT:/github-output"  \
-            -v "${{ github.workspace }}/reports:/github/workspace/reports"  \
-            --rm ${{ env.TEST_TAG }}
-
-      - name: Upload JUnit report
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: rit-junit-report
-          path: reports/junit.xml
-          if-no-files-found: warn
-
-      # Render the JUnit report (and per-phase timing, when present) into the run summary.
-      # always() so the breakdown is produced on failing runs too; the script never exits
-      # non-zero, so it cannot turn a passing run red. Per-file durations here are the input
-      # the sharding work (P2-01/P2-02) uses to balance shards against the serial baseline.
-      - name: Test timing summary
-        if: always()
-        run: node scripts/ci-timing-summary.js reports/junit.xml reports/phase-timing.json >> "$GITHUB_STEP_SUMMARY"
-
-      # Surface failing tests as a PR check with per-test annotations instead of only in the
-      # ~40-min raw log. always() so failures are still reported. Skipped for fork PRs, whose
-      # read-only token can't create the check (they'd only produce a confusing failed-but-
-      # ignored step); fail-on-error/fail-on-empty stay false as a guard for empty reports.
-      - name: Publish test report (PR annotations)
-        if: >-
-          always() &&
-          (github.event_name != 'pull_request' ||
-           github.event.pull_request.head.repo.full_name == github.repository)
-        uses: dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3 # v3.0.0
-        with:
-          name: RIT Test Results
-          path: reports/junit.xml
-          reporter: java-junit
-          fail-on-error: false
-          fail-on-empty: false
-
       - name: Check Slack Token
         id: check-slack-token
-        # always() so this still runs (and the failure-notification step can gate on its output)
-        # even if a step above failed.
         if: always()
-        # Kept in its own step-scoped env (not job-level) so the token itself is never exposed
-        # to other steps; only a boolean flag is exposed as an output.
         env:
           SLACK_NOTIFICATION_TOKEN: ${{ secrets.GHA_SLACK_NOTIFICATION_TOKEN }}
         run: |
@@ -222,7 +352,9 @@ jobs:
           fi
 
       - name: Send Slack Notification on Success
-        if: success() && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login == 'rsksmart')) && steps.check-slack-token.outputs.has_token == 'true'
+        # always() so the earlier gate step's exit 1 (on shard failure) doesn't skip this via the
+        # implicit success() — the result gate below decides which notification actually fires.
+        if: always() && needs.test-container-action.result == 'success' && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login == 'rsksmart')) && steps.check-slack-token.outputs.has_token == 'true'
         # Notifications are best-effort: a Slack API failure must not flip the CI result.
         continue-on-error: true
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
@@ -258,9 +390,11 @@ jobs:
                     url: "${{ env.BUILD_URL }}"
 
       - name: Send Slack Notification on Failure
-        if: failure() && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login == 'rsksmart')) && steps.check-slack-token.outputs.has_token == 'true'
-        # Notifications are best-effort: a Slack API failure must not add noise on top of
-        # the real CI failure.
+        # always() so this still fires after the gate step's exit 1 on shard failure (the implicit
+        # success() would otherwise skip it — exactly when the failure notice is needed).
+        if: always() && needs.test-container-action.result != 'success' && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login == 'rsksmart')) && steps.check-slack-token.outputs.has_token == 'true'
+        # Notifications are best-effort: a Slack API failure must not add noise on top of the real
+        # CI failure.
         continue-on-error: true
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
@@ -296,12 +430,12 @@ jobs:
                       text: View Actions Run
                     url: "${{ env.BUILD_URL }}"
 
-  # Publishes the prebuilt image to GHCR only from main, after tests pass. Note that consumers of
-  # the action itself (uses: rsksmart/rootstock-integration-tests@main) rebuild from the Dockerfile
-  # at run time; the GHCR image is for running the suite directly with docker run.
+  # Publishes the prebuilt image to GHCR only from main, after the aggregate gate passes. Note that
+  # consumers of the action itself (uses: rsksmart/rootstock-integration-tests@main) rebuild from
+  # the Dockerfile at run time; the GHCR image is for running the suite directly with docker run.
   publish-container-action-image:
     name: Publish Image (main only)
-    needs: test-container-action
+    needs: aggregate
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -341,5 +475,5 @@ jobs:
           tags: ${{ env.LATEST_TAG }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          # Replays the layers already built (and fully cached with mode=max) by the test job.
+          # Replays the layers already built (and fully cached with mode=max) by the prepare job.
           cache-from: type=gha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,39 +50,19 @@ jobs:
   # suite (extra/ skipped) stays a single shard — no fan-out overhead for the fast PR subset.
   # ---------------------------------------------------------------------------------------------
   prepare:
-    name: Prepare (build jar once + shard matrix)
+    name: Prepare (resolve suite + shard matrix)
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 10
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       rskj_branch: ${{ steps.vars.outputs.rskj_branch }}
       powpeg_branch: ${{ steps.vars.outputs.powpeg_branch }}
       rit_branch: ${{ steps.vars.outputs.rit_branch }}
       test_suite: ${{ steps.vars.outputs.test_suite }}
-      powpeg_version: ${{ steps.build-jar.outputs.powpeg_version }}
     steps:
       - name: Checkout
         id: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Setup Docker BuildX
-        id: setup-buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-        with:
-          install: true
-          driver-opts: network=host
-          platforms: linux/amd64
-
-      # Build + load the image here (cache-to mode=max). We docker-run it below to build the jar,
-      # and each shard replays the same cached layers instead of rebuilding the image N times.
-      - name: Build and export locally Docker
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: container-action/
-          load: true
-          tags: ${{ env.TEST_TAG }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Set Branch Variables
         uses: ./.github/actions/set-branch-variables
@@ -108,19 +88,24 @@ jobs:
         run: |
           # Full-suite shard definitions (the P2-01 state groups). Always emitted — even on a short
           # run — so the coverage check below can validate them on every event.
+          # `mode` selects how the container runs: "test" consumes the prebuilt jar from the
+          # build-jar job; "all" is the original single-container clone+build+test.
           full_matrix='{"include":[
-            {"name":"federation-change","cases":"00_sync,01_powpeg/01-change-federation,01_powpeg/extra/04-change-federation-full"},
-            {"name":"2wp","cases":"00_sync,01_powpeg/02-2wp,01_powpeg/extra/05-2wp-full"},
-            {"name":"bridge-methods","cases":"00_sync,01_powpeg/extra/03,01_powpeg/extra/06,01_powpeg/extra/08,01_powpeg/extra/09,01_powpeg/extra/12,01_powpeg/extra/13,01_powpeg/extra/14,01_powpeg/extra/15"},
-            {"name":"bridge-state-changes","cases":"00_sync,01_powpeg/extra/01,01_powpeg/extra/02,01_powpeg/extra/07,01_powpeg/extra/10,01_powpeg/extra/11"}
+            {"name":"federation-change","mode":"test","cases":"00_sync,01_powpeg/01-change-federation,01_powpeg/extra/04-change-federation-full"},
+            {"name":"2wp","mode":"test","cases":"00_sync,01_powpeg/02-2wp,01_powpeg/extra/05-2wp-full"},
+            {"name":"bridge-methods","mode":"test","cases":"00_sync,01_powpeg/extra/03,01_powpeg/extra/06,01_powpeg/extra/08,01_powpeg/extra/09,01_powpeg/extra/12,01_powpeg/extra/13,01_powpeg/extra/14,01_powpeg/extra/15"},
+            {"name":"bridge-state-changes","mode":"test","cases":"00_sync,01_powpeg/extra/01,01_powpeg/extra/02,01_powpeg/extra/07,01_powpeg/extra/10,01_powpeg/extra/11"}
           ]}'
           # Collapse to a single line so it is valid as a matrix expression.
           full_matrix=$(echo "$full_matrix" | tr -d '\n' | tr -s ' ')
           echo "full_matrix=$full_matrix" >> "$GITHUB_OUTPUT"
 
           if [ "$TEST_SUITE" = "short" ]; then
-            # The short suite skips extra/ entirely (only 3 files run); no fan-out benefit.
-            matrix='{"include":[{"name":"short","cases":""}]}'
+            # The short suite skips extra/ entirely (only 3 files run), so there is nothing to fan
+            # out. Splitting it into build-then-test only adds a second runner, an artifact
+            # round-trip and ~1-2 min for no parallelism, so run it as one 'all'-mode container —
+            # the same path rskj/powpeg-node use, which keeps that path exercised on every PR.
+            matrix='{"include":[{"name":"short","mode":"all","cases":""}]}'
           else
             matrix="$full_matrix"
           fi
@@ -135,9 +120,41 @@ jobs:
           MATRIX: ${{ steps.set-matrix.outputs.full_matrix }}
         run: node scripts/ci-check-shard-coverage.js "$MATRIX"
 
-      # Build-once (P2-02 / P1-01): run the container in build mode to clone + build rskj + powpeg
-      # into the fat jar exactly once. The entrypoint stages the jar into ${workspace}/jar and
-      # emits powpeg_version; each shard downloads the jar instead of re-paying the ~5 min build.
+  # ---------------------------------------------------------------------------------------------
+  # Build-once (P2-02 / P1-01): clone + build rskj + powpeg into the fat jar exactly once, so the
+  # shards do not each re-pay it. Full suite only — the short suite runs a single 'all'-mode
+  # container that builds and tests together, so there is nothing to hand off.
+  # ---------------------------------------------------------------------------------------------
+  build-jar:
+    name: Build powpeg jar (once)
+    needs: prepare
+    if: needs.prepare.outputs.test_suite != 'short'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    outputs:
+      powpeg_version: ${{ steps.build-jar.outputs.powpeg_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Docker BuildX
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          install: true
+          driver-opts: network=host
+          platforms: linux/amd64
+
+      # Build + load the image here (cache-to mode=max) so each shard replays the same cached
+      # layers instead of rebuilding the image N times.
+      - name: Build and export locally Docker
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: container-action/
+          load: true
+          tags: ${{ env.TEST_TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Build powpeg jar (build-once)
         id: build-jar
         run: |
@@ -146,8 +163,8 @@ jobs:
             --env GITHUB_OUTPUT="/github-output" \
             --env GITHUB_WORKSPACE="/github/workspace" \
             --env INPUT_MODE="build" \
-            --env INPUT_RSKJ_BRANCH="${{ env.RSKJ_BRANCH }}" \
-            --env INPUT_POWPEG_NODE_BRANCH="${{ env.POWPEG_BRANCH }}" \
+            --env INPUT_RSKJ_BRANCH="${{ needs.prepare.outputs.rskj_branch }}" \
+            --env INPUT_POWPEG_NODE_BRANCH="${{ needs.prepare.outputs.powpeg_branch }}" \
             --env INPUT_RIT_LOG_LEVEL="info" \
             -v "$GITHUB_OUTPUT:/github-output" \
             -v "${{ github.workspace }}/jar:/github/workspace/jar" \
@@ -170,7 +187,11 @@ jobs:
   # ---------------------------------------------------------------------------------------------
   test-container-action:
     name: RIT (${{ matrix.name }})
-    needs: prepare
+    needs: [prepare, build-jar]
+    # build-jar is skipped on the short suite, which must not skip the tests with it.
+    if: >-
+      always() && needs.prepare.result == 'success' &&
+      (needs.build-jar.result == 'success' || needs.build-jar.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     # checks: write lets the test-reporter publish failures as a PR check with annotations.
@@ -196,7 +217,8 @@ jobs:
           driver-opts: network=host
           platforms: linux/amd64
 
-      # Pure cache replay of the image built in prepare (cache-to mode=max there).
+      # Replays the layers cached by build-jar on the full suite; on the short suite this is the
+      # first build of the image (and seeds the cache for later runs).
       - name: Build and export locally Docker
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
@@ -204,27 +226,32 @@ jobs:
           load: true
           tags: ${{ env.TEST_TAG }}
           cache-from: type=gha
+          cache-to: ${{ matrix.mode == 'all' && 'type=gha,mode=max' || '' }}
 
-      # Consume the jar built once in prepare instead of rebuilding rskj/powpeg per shard.
+      # Shards (mode=test) consume the jar built once by build-jar. The short suite runs mode=all,
+      # which builds inside the container, so there is no artifact to fetch.
       - name: Download powpeg jar
+        if: matrix.mode == 'test'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: rit-powpeg-jar
           path: jar
 
-      - name: Run Rootstock Integration Tests (test mode)
+      - name: Run Rootstock Integration Tests (${{ matrix.mode }} mode)
         id: test-container
         env:
           INPUT_RIT_LOG_LEVEL: info
         run: |
-          mkdir -p "${{ github.workspace }}/reports"
-          # test mode: no rskj/powpeg clone/build — the prebuilt jar is mounted in and located via
-          # INPUT_POWPEG_VERSION. Only RIT is cloned + run (its shard slice via INCLUDE_CASES).
+          mkdir -p "${{ github.workspace }}/reports" "${{ github.workspace }}/jar"
+          # mode=test: no rskj/powpeg clone/build — the prebuilt jar is mounted in and located via
+          # INPUT_POWPEG_VERSION, and only RIT is cloned + run (its slice via INCLUDE_CASES).
+          # mode=all: the original single-container clone + build + test; the jar mount is unused
+          # and INPUT_POWPEG_VERSION is ignored by the entrypoint.
           docker run \
             --env GITHUB_OUTPUT="/github-output"  \
             --env GITHUB_WORKSPACE="/github/workspace"  \
-            --env INPUT_MODE="test"  \
-            --env INPUT_POWPEG_VERSION="${{ needs.prepare.outputs.powpeg_version }}"  \
+            --env INPUT_MODE="${{ matrix.mode }}"  \
+            --env INPUT_POWPEG_VERSION="${{ needs.build-jar.outputs.powpeg_version }}"  \
             --env INPUT_RIT_BRANCH="${{ needs.prepare.outputs.rit_branch }}"  \
             --env INPUT_RSKJ_BRANCH="${{ needs.prepare.outputs.rskj_branch }}"  \
             --env INPUT_POWPEG_NODE_BRANCH="${{ needs.prepare.outputs.powpeg_branch }}"  \
@@ -277,7 +304,7 @@ jobs:
   # ---------------------------------------------------------------------------------------------
   aggregate:
     name: Aggregate & gate
-    needs: [prepare, test-container-action]
+    needs: [prepare, build-jar, test-container-action]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -335,10 +362,16 @@ jobs:
 
       - name: Gate on build + shard results
         run: |
-          echo "prepare (build + matrix): ${{ needs.prepare.result }}"
-          echo "test shards (aggregate):  ${{ needs.test-container-action.result }}"
+          echo "prepare (suite + matrix): ${{ needs.prepare.result }}"
+          echo "build-jar (full only):    ${{ needs.build-jar.result }}"
+          echo "tests (aggregate):        ${{ needs.test-container-action.result }}"
           if [ "${{ needs.prepare.result }}" != "success" ]; then
-            echo "::error::The build/prepare job did not succeed."
+            echo "::error::The prepare job did not succeed."
+            exit 1
+          fi
+          # build-jar is legitimately skipped on the short suite, which runs a single all-mode job.
+          if [ "${{ needs.build-jar.result }}" != "success" ] && [ "${{ needs.build-jar.result }}" != "skipped" ]; then
+            echo "::error::The powpeg jar build did not succeed."
             exit 1
           fi
           if [ "${{ needs.test-container-action.result }}" != "success" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,15 +50,16 @@ jobs:
   # suite (extra/ skipped) stays a single shard — no fan-out overhead for the fast PR subset.
   # ---------------------------------------------------------------------------------------------
   prepare:
-    name: Prepare (build image + shard matrix)
+    name: Prepare (build jar once + shard matrix)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       rskj_branch: ${{ steps.vars.outputs.rskj_branch }}
       powpeg_branch: ${{ steps.vars.outputs.powpeg_branch }}
       rit_branch: ${{ steps.vars.outputs.rit_branch }}
       test_suite: ${{ steps.vars.outputs.test_suite }}
+      powpeg_version: ${{ steps.build-jar.outputs.powpeg_version }}
     steps:
       - name: Checkout
         id: checkout
@@ -72,12 +73,13 @@ jobs:
           driver-opts: network=host
           platforms: linux/amd64
 
-      # Build once here to populate the gha layer cache (mode=max). Each shard then replays the
-      # cache instead of racing to build the same image N times in parallel.
-      - name: Warm Docker layer cache
+      # Build + load the image here (cache-to mode=max). We docker-run it below to build the jar,
+      # and each shard replays the same cached layers instead of rebuilding the image N times.
+      - name: Build and export locally Docker
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: container-action/
+          load: true
           tags: ${{ env.TEST_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -118,6 +120,33 @@ jobs:
           # Collapse to a single line so it is valid as a matrix expression.
           matrix=$(echo "$matrix" | tr -d '\n' | tr -s ' ')
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+      # Build-once (P2-02 / P1-01): run the container in build mode to clone + build rskj + powpeg
+      # into the fat jar exactly once. The entrypoint stages the jar into ${workspace}/jar and
+      # emits powpeg_version; each shard downloads the jar instead of re-paying the ~5 min build.
+      - name: Build powpeg jar (build-once)
+        id: build-jar
+        run: |
+          mkdir -p "${{ github.workspace }}/jar"
+          docker run \
+            --env GITHUB_OUTPUT="/github-output" \
+            --env GITHUB_WORKSPACE="/github/workspace" \
+            --env INPUT_MODE="build" \
+            --env INPUT_RSKJ_BRANCH="${{ env.RSKJ_BRANCH }}" \
+            --env INPUT_POWPEG_NODE_BRANCH="${{ env.POWPEG_BRANCH }}" \
+            --env INPUT_RIT_LOG_LEVEL="info" \
+            -v "$GITHUB_OUTPUT:/github-output" \
+            -v "${{ github.workspace }}/jar:/github/workspace/jar" \
+            --rm ${{ env.TEST_TAG }}
+
+      - name: Upload powpeg jar
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: rit-powpeg-jar
+          path: jar/federate-node-*-all.jar
+          if-no-files-found: error
+          # Short retention: this is an intra-run handoff to the shards, not a lasting artifact.
+          retention-days: 1
 
   # ---------------------------------------------------------------------------------------------
   # One job per shard. fail-fast:false so a failing shard doesn't cancel the others; the
@@ -160,22 +189,32 @@ jobs:
           tags: ${{ env.TEST_TAG }}
           cache-from: type=gha
 
-      - name: Run Rootstock Integration Tests
+      # Consume the jar built once in prepare instead of rebuilding rskj/powpeg per shard.
+      - name: Download powpeg jar
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: rit-powpeg-jar
+          path: jar
+
+      - name: Run Rootstock Integration Tests (test mode)
         id: test-container
         env:
           INPUT_RIT_LOG_LEVEL: info
         run: |
           mkdir -p "${{ github.workspace }}/reports"
+          # test mode: no rskj/powpeg clone/build — the prebuilt jar is mounted in and located via
+          # INPUT_POWPEG_VERSION. Only RIT is cloned + run (its shard slice via INCLUDE_CASES).
           docker run \
             --env GITHUB_OUTPUT="/github-output"  \
             --env GITHUB_WORKSPACE="/github/workspace"  \
-            --env INPUT_RSKJ_BRANCH="${{ needs.prepare.outputs.rskj_branch }}"  \
-            --env INPUT_POWPEG_NODE_BRANCH="${{ needs.prepare.outputs.powpeg_branch }}"  \
+            --env INPUT_MODE="test"  \
+            --env INPUT_POWPEG_VERSION="${{ needs.prepare.outputs.powpeg_version }}"  \
             --env INPUT_RIT_BRANCH="${{ needs.prepare.outputs.rit_branch }}"  \
             --env INPUT_RIT_LOG_LEVEL="${{ env.INPUT_RIT_LOG_LEVEL }}" \
             --env INPUT_TEST_SUITE="${{ needs.prepare.outputs.test_suite }}" \
             --env INPUT_INCLUDE_CASES="${{ matrix.cases }}" \
             -v "$GITHUB_OUTPUT:/github-output"  \
+            -v "${{ github.workspace }}/jar:/github/workspace/jar"  \
             -v "${{ github.workspace }}/reports:/github/workspace/reports"  \
             --rm ${{ env.TEST_TAG }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,10 +111,10 @@ jobs:
             matrix='{"include":[{"name":"short","cases":""}]}'
           else
             matrix='{"include":[
-              {"name":"federation","cases":"00_sync,01_powpeg/01-change-federation,01_powpeg/extra/04-change-federation-full"},
+              {"name":"federation-change","cases":"00_sync,01_powpeg/01-change-federation,01_powpeg/extra/04-change-federation-full"},
               {"name":"2wp","cases":"00_sync,01_powpeg/02-2wp,01_powpeg/extra/05-2wp-full"},
-              {"name":"bridge-queries","cases":"00_sync,01_powpeg/extra/03,01_powpeg/extra/06,01_powpeg/extra/08,01_powpeg/extra/09,01_powpeg/extra/12,01_powpeg/extra/13,01_powpeg/extra/14,01_powpeg/extra/15"},
-              {"name":"param-mutators","cases":"00_sync,01_powpeg/extra/01,01_powpeg/extra/02,01_powpeg/extra/07,01_powpeg/extra/10,01_powpeg/extra/11"}
+              {"name":"bridge-methods","cases":"00_sync,01_powpeg/extra/03,01_powpeg/extra/06,01_powpeg/extra/08,01_powpeg/extra/09,01_powpeg/extra/12,01_powpeg/extra/13,01_powpeg/extra/14,01_powpeg/extra/15"},
+              {"name":"bridge-state-changes","cases":"00_sync,01_powpeg/extra/01,01_powpeg/extra/02,01_powpeg/extra/07,01_powpeg/extra/10,01_powpeg/extra/11"}
             ]}'
           fi
           # Collapse to a single line so it is valid as a matrix expression.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,26 +106,33 @@ jobs:
       - name: Compute shard matrix
         id: set-matrix
         run: |
+          # Full-suite shard definitions (the P2-01 state groups). Always emitted — even on a short
+          # run — so the coverage check below can validate them on every event.
+          full_matrix='{"include":[
+            {"name":"federation-change","cases":"00_sync,01_powpeg/01-change-federation,01_powpeg/extra/04-change-federation-full"},
+            {"name":"2wp","cases":"00_sync,01_powpeg/02-2wp,01_powpeg/extra/05-2wp-full"},
+            {"name":"bridge-methods","cases":"00_sync,01_powpeg/extra/03,01_powpeg/extra/06,01_powpeg/extra/08,01_powpeg/extra/09,01_powpeg/extra/12,01_powpeg/extra/13,01_powpeg/extra/14,01_powpeg/extra/15"},
+            {"name":"bridge-state-changes","cases":"00_sync,01_powpeg/extra/01,01_powpeg/extra/02,01_powpeg/extra/07,01_powpeg/extra/10,01_powpeg/extra/11"}
+          ]}'
+          # Collapse to a single line so it is valid as a matrix expression.
+          full_matrix=$(echo "$full_matrix" | tr -d '\n' | tr -s ' ')
+          echo "full_matrix=$full_matrix" >> "$GITHUB_OUTPUT"
+
           if [ "$TEST_SUITE" = "short" ]; then
             # The short suite skips extra/ entirely (only 3 files run); no fan-out benefit.
             matrix='{"include":[{"name":"short","cases":""}]}'
           else
-            matrix='{"include":[
-              {"name":"federation-change","cases":"00_sync,01_powpeg/01-change-federation,01_powpeg/extra/04-change-federation-full"},
-              {"name":"2wp","cases":"00_sync,01_powpeg/02-2wp,01_powpeg/extra/05-2wp-full"},
-              {"name":"bridge-methods","cases":"00_sync,01_powpeg/extra/03,01_powpeg/extra/06,01_powpeg/extra/08,01_powpeg/extra/09,01_powpeg/extra/12,01_powpeg/extra/13,01_powpeg/extra/14,01_powpeg/extra/15"},
-              {"name":"bridge-state-changes","cases":"00_sync,01_powpeg/extra/01,01_powpeg/extra/02,01_powpeg/extra/07,01_powpeg/extra/10,01_powpeg/extra/11"}
-            ]}'
+            matrix="$full_matrix"
           fi
-          # Collapse to a single line so it is valid as a matrix expression.
-          matrix=$(echo "$matrix" | tr -d '\n' | tr -s ' ')
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
       # Shard membership is a hardcoded list, so a newly added test file could otherwise land in no
       # shard and silently never run. Fail here instead (also catches stale/typo'd patterns).
+      # Always checked against the FULL shard definitions, so a short-suite PR that adds a test
+      # still fails here rather than only after it merges and main runs the full suite.
       - name: Verify shard coverage
         env:
-          MATRIX: ${{ steps.set-matrix.outputs.matrix }}
+          MATRIX: ${{ steps.set-matrix.outputs.full_matrix }}
         run: node scripts/ci-check-shard-coverage.js "$MATRIX"
 
       # Build-once (P2-02 / P1-01): run the container in build mode to clone + build rskj + powpeg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,23 +283,32 @@ jobs:
           pattern: rit-junit-report-*
           path: shard-reports
 
-      - name: Consolidated timing summary (all shards)
+      # Merge the per-shard reports into ONE cumulative JUnit document for the whole run. Each
+      # shard reran the 00_sync bootstrap, so that suite appears once per shard in the merge.
+      - name: Merge shard JUnit reports (cumulative)
+        if: always()
+        continue-on-error: true
+        run: node scripts/ci-merge-junit.js shard-reports reports/junit.xml
+
+      - name: Upload cumulative JUnit report
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: rit-junit-report
+          path: reports/junit.xml
+          if-no-files-found: warn
+
+      # One cumulative timing table over the merged report (each shard also writes its own).
+      - name: Cumulative timing summary
         if: always()
         continue-on-error: true
         run: |
-          echo "# ⏱️ Consolidated test timing (all shards)" >> "$GITHUB_STEP_SUMMARY"
-          shopt -s nullglob
-          found=0
-          for report in shard-reports/*/junit.xml; do
-            found=1
-            shard_name=$(basename "$(dirname "$report")" | sed 's/^rit-junit-report-//')
-            echo "## 🧩 Shard: ${shard_name}" >> "$GITHUB_STEP_SUMMARY"
-            # The timing script never exits non-zero, but guard anyway so one bad report can't fail
-            # the consolidation (it is a reporting nicety, not a gate).
-            node scripts/ci-timing-summary.js "$report" >> "$GITHUB_STEP_SUMMARY" || true
-          done
-          if [ "$found" = "0" ]; then
-            echo "> No shard JUnit reports were downloaded." >> "$GITHUB_STEP_SUMMARY"
+          echo "# ⏱️ Cumulative test timing (all shards)" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f reports/junit.xml ]; then
+            node scripts/ci-timing-summary.js reports/junit.xml >> "$GITHUB_STEP_SUMMARY" || true
+          else
+            echo "> No cumulative JUnit report was produced." >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Gate on build + shard results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,8 +217,9 @@ jobs:
           driver-opts: network=host
           platforms: linux/amd64
 
-      # Replays the layers cached by build-jar on the full suite; on the short suite this is the
-      # first build of the image (and seeds the cache for later runs).
+      # Consume the layer cache only. It is written by build-jar (full suite) and by the publish
+      # job on main, both with mode=max, so there is nothing useful for this job to export — and
+      # four shards writing the same cache concurrently would only cause contention.
       - name: Build and export locally Docker
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
@@ -226,7 +227,6 @@ jobs:
           load: true
           tags: ${{ env.TEST_TAG }}
           cache-from: type=gha
-          cache-to: ${{ matrix.mode == 'all' && 'type=gha,mode=max' || '' }}
 
       # Shards (mode=test) consume the jar built once by build-jar. The short suite runs mode=all,
       # which builds inside the container, so there is no artifact to fetch.
@@ -578,5 +578,5 @@ jobs:
           tags: ${{ env.LATEST_TAG }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          # Replays the layers already built (and fully cached with mode=max) by the prepare job.
+          # Replays the layers already built (and fully cached with mode=max) by the build-jar job.
           cache-from: type=gha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,13 @@ jobs:
           matrix=$(echo "$matrix" | tr -d '\n' | tr -s ' ')
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
+      # Shard membership is a hardcoded list, so a newly added test file could otherwise land in no
+      # shard and silently never run. Fail here instead (also catches stale/typo'd patterns).
+      - name: Verify shard coverage
+        env:
+          MATRIX: ${{ steps.set-matrix.outputs.matrix }}
+        run: node scripts/ci-check-shard-coverage.js "$MATRIX"
+
       # Build-once (P2-02 / P1-01): run the container in build mode to clone + build rskj + powpeg
       # into the fat jar exactly once. The entrypoint stages the jar into ${workspace}/jar and
       # emits powpeg_version; each shard downloads the jar instead of re-paying the ~5 min build.
@@ -147,6 +154,8 @@ jobs:
           if-no-files-found: error
           # Short retention: this is an intra-run handoff to the shards, not a lasting artifact.
           retention-days: 1
+          # Let a re-run replace the previous attempt's artifact instead of failing on a name clash.
+          overwrite: true
 
   # ---------------------------------------------------------------------------------------------
   # One job per shard. fail-fast:false so a failing shard doesn't cancel the others; the
@@ -210,6 +219,8 @@ jobs:
             --env INPUT_MODE="test"  \
             --env INPUT_POWPEG_VERSION="${{ needs.prepare.outputs.powpeg_version }}"  \
             --env INPUT_RIT_BRANCH="${{ needs.prepare.outputs.rit_branch }}"  \
+            --env INPUT_RSKJ_BRANCH="${{ needs.prepare.outputs.rskj_branch }}"  \
+            --env INPUT_POWPEG_NODE_BRANCH="${{ needs.prepare.outputs.powpeg_branch }}"  \
             --env INPUT_RIT_LOG_LEVEL="${{ env.INPUT_RIT_LOG_LEVEL }}" \
             --env INPUT_TEST_SUITE="${{ needs.prepare.outputs.test_suite }}" \
             --env INPUT_INCLUDE_CASES="${{ matrix.cases }}" \
@@ -225,6 +236,8 @@ jobs:
           name: rit-junit-report-${{ matrix.name }}
           path: reports/junit.xml
           if-no-files-found: warn
+          # Let a re-run of a failed shard replace its earlier report instead of failing on a clash.
+          overwrite: true
 
       # Render this shard's JUnit report (and per-phase timing, when present) into the run summary.
       # always() so the breakdown is produced on failing runs too; the script never exits non-zero,
@@ -298,6 +311,8 @@ jobs:
           name: rit-junit-report
           path: reports/junit.xml
           if-no-files-found: warn
+          # Re-runs recompute the cumulative report; replace rather than clash on the name.
+          overwrite: true
 
       # One cumulative timing table over the merged report (each shard also writes its own).
       - name: Cumulative timing summary

--- a/README.md
+++ b/README.md
@@ -180,6 +180,46 @@ Patterns match either the bare filename or the path relative to `tests/`, so a g
 
 Since file numbering is folder-local, a number-only pattern like `01-` can match files in several folders. Use the descriptive part of the filename or a path-qualified pattern to disambiguate.
 
+## CI shards: adding a new test file
+
+In CI the full suite does not run serially. It fans out into parallel **shards**, each of which boots its own bitcoind + federate cluster, runs the shared bootstrap, and then executes its own group of test files via the `INCLUDE_CASES` mechanism described above. Shard membership is declared in the `Compute shard matrix` step of [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+
+The grouping is not arbitrary — it follows what each file requires from, and leaves behind in, the shared chain state:
+
+| Shard | Contains | Why these belong together |
+| --- | --- | --- |
+| `federation-change` | `01-change-federation`, `extra/04-change-federation-full` | The federation lineage is one-way and cumulative (genesis → second → third). `04` needs the federation that `01` produces, so they must stay in this order, in the same shard. |
+| `2wp` | `02-2wp`, `extra/05-2wp-full` | Peg-in/peg-out. Federation-agnostic (they resolve the active federation at runtime) and assert balances relatively, so they need no federation change first. |
+| `bridge-methods` | `extra/03, 06, 08, 09, 12, 13, 14, 15` | Bridge queries and self-contained mutations — read-only calls, header submission, coinbase registration, precompile checks. |
+| `bridge-state-changes` | `extra/01, 02, 07, 10, 11` | Tests that change **global bridge state** for everything after them: locking cap (permanently raised to 21M), fee-per-kb, whitelist, UTXO churn, and union-bridge configuration. Kept apart so they cannot contaminate the shards above. |
+
+Every shard's `INCLUDE_CASES` starts with `00_sync`, because each shard runs on a fresh chain and that file establishes the mandatory bootstrap state (it mines RSK to height 515 and asserts exactly that, so it must be the first miner on a fresh chain).
+
+### When you add a test file
+
+**Add it to a shard in `ci.yml`.** CI will not let you forget: the `Verify shard coverage` step in the `prepare` job fails the build when a runnable test file is not assigned to any shard (and when a shard pattern no longer matches any file, e.g. after a rename):
+
+```
+::error::Test file not assigned to any CI shard: tests/01_powpeg/03-my-new-test.js
+        — add it to a shard in .github/workflows/ci.yml
+```
+
+To pick the right shard, ask what the test does to shared state:
+
+- Needs a **specific federation generation** (not genesis) → `federation-change`, after the file that produces that state.
+- Exercises **peg-in / peg-out** → `2wp`.
+- **Permanently changes a global bridge parameter** (locking cap, fee-per-kb, whitelist, union-bridge config) or churns federation UTXOs → `bridge-state-changes`.
+- **Queries the bridge**, or mutates only state it owns → `bridge-methods`.
+
+If a test is `describe.skip`-ed it does not need a shard; the coverage check ignores skipped files.
+
+Two things to keep in mind:
+
+- Shard patterns are **prefix matches**, so a new file that shares a numeric prefix with an existing pattern (e.g. another `extra/03-*`) is silently absorbed into that shard. The coverage check sees it as covered, so choose the shard deliberately rather than relying on the check.
+- Adding an `it` to a file that is already in a shard needs no CI change.
+
+Shards are also the reason to keep a file self-contained where you can: the fewer prerequisites a file has, the freer it is to move between shards later.
+
 ## Running the tests on an existing running bitcoind and/or federate node(s)
 
 Coming soon...

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: "Which test suite to run: 'short' (fast PR subset) or 'full' (short + extra tests)"
     required: false
     default: 'full'
+  include-cases:
+    description: "Optional comma-separated file/path prefixes to run only a subset of tests (sharding). Empty runs the whole suite. Matches the INCLUDE_CASES mechanism in test.js."
+    required: false
+    default: ''
 
 outputs:
   status:
@@ -54,3 +58,4 @@ runs:
     INPUT_RSKJ_REPO: ${{ inputs.rskj-repo }}
     INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
     INPUT_TEST_SUITE: ${{ inputs.test-suite }}
+    INPUT_INCLUDE_CASES: ${{ inputs.include-cases }}

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,14 @@ inputs:
     description: "Optional comma-separated file/path prefixes to run only a subset of tests (sharding). Empty runs the whole suite. Matches the INCLUDE_CASES mechanism in test.js."
     required: false
     default: ''
+  mode:
+    description: "Execution mode (build-once split). 'all' (default) clones+builds rskj/powpeg AND runs the tests in one container — the original behaviour. 'build' only builds the fat jar and stages it. 'test' skips the build and runs the tests against a prebuilt jar (see powpeg-version)."
+    required: false
+    default: 'all'
+  powpeg-version:
+    description: "Required only for mode=test: the powpeg version the prebuilt jar was built with (as produced by a prior mode=build run), used to locate federate-node-<version>-all.jar."
+    required: false
+    default: ''
 
 outputs:
   status:
@@ -59,3 +67,5 @@ runs:
     INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
     INPUT_TEST_SUITE: ${{ inputs.test-suite }}
     INPUT_INCLUDE_CASES: ${{ inputs.include-cases }}
+    INPUT_MODE: ${{ inputs.mode }}
+    INPUT_POWPEG_VERSION: ${{ inputs.powpeg-version }}

--- a/container-action/entrypoint.sh
+++ b/container-action/entrypoint.sh
@@ -14,6 +14,10 @@ REPO_OWNER="${INPUT_REPO_OWNER:-rsksmart}"  # Default to 'rsksmart' if not provi
 RSKJ_REPO="${INPUT_RSKJ_REPO:-rskj}"        # Name of the base rskj repo; default to 'rskj'
 GH_TOKEN="${INPUT_GITHUB_TOKEN}"            # Optional; required to clone a private base rskj repo
 TEST_SUITE="${INPUT_TEST_SUITE:-full}"      # Default to 'full' (long) suite if not provided
+# Optional comma-separated file/path prefixes to run only a subset of tests (sharding). Empty
+# means run the whole suite — the default, so rskj/powpeg-node callers (which never set this)
+# are unaffected. Consumed by test.js via the INCLUDE_CASES env var.
+INCLUDE_CASES="${INPUT_INCLUDE_CASES:-}"
 
 # Resolve whether a git ref exists in a GitHub repository. The inputs may be a
 # branch, a tag or a specific commit (see container-action/README.md), so we use
@@ -59,6 +63,7 @@ echo "LOG_LEVEL=$LOG_LEVEL"
 echo "REPO_OWNER=$REPO_OWNER"
 echo "RSKJ_REPO=$RSKJ_REPO"
 echo "TEST_SUITE=$TEST_SUITE"
+echo "INCLUDE_CASES=${INCLUDE_CASES:-<all>}"
 
 echo -e "\n\n--------- Starting the configuration of rskj ---------\n\n"
 cd /usr/src/
@@ -143,6 +148,12 @@ chmod +x ./configure_rit_locally.sh
 ./configure_rit_locally.sh "${POWPEG_VERSION}"
 
 export LOG_LEVEL="$LOG_LEVEL"
+
+# Export the shard selection (if any) so test.js runs only the requested subset. Left unset when
+# empty so the default whole-suite behaviour is untouched for callers that don't shard.
+if [[ -n "$INCLUDE_CASES" ]]; then
+  export INCLUDE_CASES
+fi
 
 # --- P0-01: preserve the JUnit report for CI artifact upload (on pass or fail) ---
 # The suite writes reports/junit.xml inside this container. GITHUB_WORKSPACE is the

--- a/container-action/entrypoint.sh
+++ b/container-action/entrypoint.sh
@@ -142,7 +142,29 @@ chmod +x ./configure.sh && chmod +x gradlew
 POWPEG_VERSION=$(bash configure_gradle_powpeg.sh)
 echo "POWPEG_VERSION=$POWPEG_VERSION"
 ./configure.sh
-./gradlew  --info --no-daemon --dependency-verification=lenient clean build -x test
+
+# The Gradle wrapper downloads its distribution on first use and resolves dependencies over the
+# network; both have produced transient 5xx failures (e.g. a 504 fetching gradle-8.6-bin.zip) that
+# sink an otherwise healthy build. Retry with backoff before giving up. This matters more under the
+# build-once split, where a single build feeds every test shard, and it equally protects the
+# single-container 'all' path that rskj/powpeg-node CI uses.
+run_gradle_build() {
+  local attempt=1 max_attempts=3 delay=30
+  while true; do
+    if ./gradlew --info --no-daemon --dependency-verification=lenient clean build -x test; then
+      return 0
+    fi
+    if [ "$attempt" -ge "$max_attempts" ]; then
+      echo "Gradle build failed after ${attempt} attempt(s)." >&2
+      return 1
+    fi
+    echo "Gradle build attempt ${attempt} failed; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
+run_gradle_build
 
 fi  # end build phase
 

--- a/container-action/entrypoint.sh
+++ b/container-action/entrypoint.sh
@@ -60,7 +60,7 @@ ref_status() {
 
 # Only resolve rskj/powpeg refs when we are going to build (all/build modes). Test mode consumes a
 # prebuilt jar and never clones, so skip these API calls there.
-if [ "$MODE" != "test" ]; then
+if [[ "$MODE" != "test" ]]; then
   RSKJ_REF_STATUS=$(ref_status "$REPO_OWNER" "$RSKJ_REPO" "$RSKJ_BRANCH")
   POWPEG_REF_STATUS=$(ref_status "$REPO_OWNER" "powpeg-node" "$POWPEG_NODE_BRANCH")
 fi
@@ -78,7 +78,7 @@ echo "MODE=$MODE"
 
 # Build phase (clone + build rskj + powpeg into the fat jar). Runs in 'all' and 'build' modes;
 # skipped in 'test' mode, which consumes a prebuilt jar instead.
-if [ "$MODE" != "test" ]; then
+if [[ "$MODE" != "test" ]]; then
 
 echo -e "\n\n--------- Starting the configuration of rskj ---------\n\n"
 cd /usr/src/
@@ -154,7 +154,7 @@ run_gradle_build() {
     if ./gradlew --info --no-daemon --dependency-verification=lenient clean build -x test; then
       return 0
     fi
-    if [ "$attempt" -ge "$max_attempts" ]; then
+    if [[ "$attempt" -ge "$max_attempts" ]]; then
       echo "Gradle build failed after ${attempt} attempt(s)." >&2
       return 1
     fi
@@ -170,16 +170,16 @@ fi  # end build phase
 
 # --- Build-once split (P2-02) -----------------------------------------------------------------
 # 'build' mode: stage the fat jar + its version for the shard (test) jobs, then stop — no tests.
-if [ "$MODE" = "build" ]; then
+if [[ "$MODE" == "build" ]]; then
   JAR="/usr/src/powpeg/build/libs/federate-node-${POWPEG_VERSION}-all.jar"
-  if [ ! -f "$JAR" ]; then
+  if [[ ! -f "$JAR" ]]; then
     echo "Error: expected powpeg jar not found at $JAR after the build." >&2
     exit 1
   fi
   mkdir -p "${GITHUB_WORKSPACE}/jar"
   cp "$JAR" "${GITHUB_WORKSPACE}/jar/"
   # Expose the version so the shard jobs can locate the same jar filename.
-  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
     echo "powpeg_version=${POWPEG_VERSION}" >> "$GITHUB_OUTPUT"
   fi
   echo "Build-only mode: staged $(basename "$JAR") to ${GITHUB_WORKSPACE}/jar; exiting before tests."
@@ -188,14 +188,14 @@ fi
 
 # 'test' mode: no build happened. Take the version from the build job and drop the prebuilt jar
 # (supplied via the mounted ${GITHUB_WORKSPACE}/jar) where configure_rit_locally.sh expects it.
-if [ "$MODE" = "test" ]; then
+if [[ "$MODE" == "test" ]]; then
   POWPEG_VERSION="${POWPEG_VERSION_INPUT}"
-  if [ -z "$POWPEG_VERSION" ]; then
+  if [[ -z "$POWPEG_VERSION" ]]; then
     echo "Error: test mode requires INPUT_POWPEG_VERSION (produced by the build job)." >&2
     exit 1
   fi
   PREBUILT_JAR="${GITHUB_WORKSPACE}/jar/federate-node-${POWPEG_VERSION}-all.jar"
-  if [ ! -f "$PREBUILT_JAR" ]; then
+  if [[ ! -f "$PREBUILT_JAR" ]]; then
     echo "Error: prebuilt jar not found at $PREBUILT_JAR (expected the build artifact to be mounted)." >&2
     exit 1
   fi

--- a/container-action/entrypoint.sh
+++ b/container-action/entrypoint.sh
@@ -18,6 +18,12 @@ TEST_SUITE="${INPUT_TEST_SUITE:-full}"      # Default to 'full' (long) suite if 
 # means run the whole suite — the default, so rskj/powpeg-node callers (which never set this)
 # are unaffected. Consumed by test.js via the INCLUDE_CASES env var.
 INCLUDE_CASES="${INPUT_INCLUDE_CASES:-}"
+# Build-once split (P2-02). 'all' (default) = clone+build rskj/powpeg AND run the tests in one
+# container — the original behaviour, so rskj/powpeg-node callers (which never set this) are
+# unaffected. 'build' = only build the fat jar and stage it for reuse. 'test' = skip the build and
+# run the tests against a prebuilt jar supplied via INPUT_POWPEG_VERSION + a mounted jar.
+MODE="${INPUT_MODE:-all}"
+POWPEG_VERSION_INPUT="${INPUT_POWPEG_VERSION:-}"
 
 # Resolve whether a git ref exists in a GitHub repository. The inputs may be a
 # branch, a tag or a specific commit (see container-action/README.md), so we use
@@ -52,8 +58,12 @@ ref_status() {
   fi
 }
 
-RSKJ_REF_STATUS=$(ref_status "$REPO_OWNER" "$RSKJ_REPO" "$RSKJ_BRANCH")
-POWPEG_REF_STATUS=$(ref_status "$REPO_OWNER" "powpeg-node" "$POWPEG_NODE_BRANCH")
+# Only resolve rskj/powpeg refs when we are going to build (all/build modes). Test mode consumes a
+# prebuilt jar and never clones, so skip these API calls there.
+if [ "$MODE" != "test" ]; then
+  RSKJ_REF_STATUS=$(ref_status "$REPO_OWNER" "$RSKJ_REPO" "$RSKJ_BRANCH")
+  POWPEG_REF_STATUS=$(ref_status "$REPO_OWNER" "powpeg-node" "$POWPEG_NODE_BRANCH")
+fi
 
 echo -e "\n\n--------- Input parameters received ---------\n\n"
 echo "RSKJ_BRANCH=$RSKJ_BRANCH"
@@ -64,6 +74,11 @@ echo "REPO_OWNER=$REPO_OWNER"
 echo "RSKJ_REPO=$RSKJ_REPO"
 echo "TEST_SUITE=$TEST_SUITE"
 echo "INCLUDE_CASES=${INCLUDE_CASES:-<all>}"
+echo "MODE=$MODE"
+
+# Build phase (clone + build rskj + powpeg into the fat jar). Runs in 'all' and 'build' modes;
+# skipped in 'test' mode, which consumes a prebuilt jar instead.
+if [ "$MODE" != "test" ]; then
 
 echo -e "\n\n--------- Starting the configuration of rskj ---------\n\n"
 cd /usr/src/
@@ -128,6 +143,44 @@ POWPEG_VERSION=$(bash configure_gradle_powpeg.sh)
 echo "POWPEG_VERSION=$POWPEG_VERSION"
 ./configure.sh
 ./gradlew  --info --no-daemon --dependency-verification=lenient clean build -x test
+
+fi  # end build phase
+
+# --- Build-once split (P2-02) -----------------------------------------------------------------
+# 'build' mode: stage the fat jar + its version for the shard (test) jobs, then stop — no tests.
+if [ "$MODE" = "build" ]; then
+  JAR="/usr/src/powpeg/build/libs/federate-node-${POWPEG_VERSION}-all.jar"
+  if [ ! -f "$JAR" ]; then
+    echo "Error: expected powpeg jar not found at $JAR after the build." >&2
+    exit 1
+  fi
+  mkdir -p "${GITHUB_WORKSPACE}/jar"
+  cp "$JAR" "${GITHUB_WORKSPACE}/jar/"
+  # Expose the version so the shard jobs can locate the same jar filename.
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "powpeg_version=${POWPEG_VERSION}" >> "$GITHUB_OUTPUT"
+  fi
+  echo "Build-only mode: staged $(basename "$JAR") to ${GITHUB_WORKSPACE}/jar; exiting before tests."
+  exit 0
+fi
+
+# 'test' mode: no build happened. Take the version from the build job and drop the prebuilt jar
+# (supplied via the mounted ${GITHUB_WORKSPACE}/jar) where configure_rit_locally.sh expects it.
+if [ "$MODE" = "test" ]; then
+  POWPEG_VERSION="${POWPEG_VERSION_INPUT}"
+  if [ -z "$POWPEG_VERSION" ]; then
+    echo "Error: test mode requires INPUT_POWPEG_VERSION (produced by the build job)." >&2
+    exit 1
+  fi
+  PREBUILT_JAR="${GITHUB_WORKSPACE}/jar/federate-node-${POWPEG_VERSION}-all.jar"
+  if [ ! -f "$PREBUILT_JAR" ]; then
+    echo "Error: prebuilt jar not found at $PREBUILT_JAR (expected the build artifact to be mounted)." >&2
+    exit 1
+  fi
+  mkdir -p /usr/src/powpeg/build/libs
+  cp "$PREBUILT_JAR" "/usr/src/powpeg/build/libs/federate-node-${POWPEG_VERSION}-all.jar"
+  echo "Test mode: using prebuilt jar federate-node-${POWPEG_VERSION}-all.jar"
+fi
 
 echo -e "\n\n--------- Starting the configuration of RIT ---------\n\n"
 

--- a/container-action/entrypoint.sh
+++ b/container-action/entrypoint.sh
@@ -25,6 +25,13 @@ INCLUDE_CASES="${INPUT_INCLUDE_CASES:-}"
 MODE="${INPUT_MODE:-all}"
 POWPEG_VERSION_INPUT="${INPUT_POWPEG_VERSION:-}"
 
+# Reject an unknown mode up front. Without this a typo (e.g. "bulid") silently falls through to
+# the default clone+build+test path, quietly doing the wrong thing instead of failing.
+if [[ "$MODE" != "all" && "$MODE" != "build" && "$MODE" != "test" ]]; then
+  echo "Error: INPUT_MODE must be one of 'all', 'build' or 'test' (got '$MODE')." >&2
+  exit 1
+fi
+
 # Resolve whether a git ref exists in a GitHub repository. The inputs may be a
 # branch, a tag or a specific commit (see container-action/README.md), so we use
 # the ref-aware REST "commits/{ref}" endpoint, which resolves all three, instead

--- a/scripts/ci-check-shard-coverage.js
+++ b/scripts/ci-check-shard-coverage.js
@@ -50,13 +50,12 @@ const listTestFiles = (dir, base = dir) => {
 const matchesPattern = (relativePath, pattern) =>
     relativePath.startsWith(pattern) || path.basename(relativePath).startsWith(pattern);
 
-function main() {
-    const raw = process.argv[2];
+// Parse and validate the matrix argument, exiting with a usage error when it is unusable.
+const parseMatrix = (raw) => {
     if (!raw) {
         writeErr('Usage: ci-check-shard-coverage.js <matrix json>');
         process.exit(2);
     }
-
     let matrix;
     try {
         matrix = JSON.parse(raw);
@@ -64,12 +63,25 @@ function main() {
         writeErr(`Could not parse the matrix JSON: ${err.message}`);
         process.exit(2);
     }
-
     const shards = matrix.include || [];
     if (shards.length === 0) {
         writeErr('The matrix has no shards.');
         process.exit(2);
     }
+    return shards;
+};
+
+// A file may be absent from every shard only if it does not run in the serial suite either.
+const isExpectedToRun = (file) => {
+    if (KNOWN_EXCLUSIONS.has(file)) {
+        return false;
+    }
+    const source = fs.readFileSync(path.join(TESTS_DIR, file), 'utf8');
+    return !source.includes('describe.skip(');
+};
+
+function main() {
+    const shards = parseMatrix(process.argv[2]);
 
     // An empty `cases` means "run everything" — nothing can be dropped.
     if (shards.some((s) => !s.cases)) {
@@ -80,22 +92,9 @@ function main() {
     const patterns = shards.flatMap((s) => s.cases.split(',').filter(Boolean));
     const files = listTestFiles(TESTS_DIR).sort();
 
-    const uncovered = [];
-    for (const file of files) {
-        if (patterns.some((p) => matchesPattern(file, p))) {
-            continue;
-        }
-        // Not in a shard — only acceptable if it does not run in the serial suite either.
-        const source = fs.readFileSync(path.join(TESTS_DIR, file), 'utf8');
-        if (source.includes('describe.skip(')) {
-            continue;
-        }
-        if (KNOWN_EXCLUSIONS.has(file)) {
-            continue;
-        }
-        uncovered.push(file);
-    }
-
+    const uncovered = files.filter(
+        (file) => !patterns.some((p) => matchesPattern(file, p)) && isExpectedToRun(file)
+    );
     // A pattern that matches nothing is usually a typo or a renamed/deleted file.
     const deadPatterns = patterns.filter((p) => !files.some((f) => matchesPattern(f, p)));
 

--- a/scripts/ci-check-shard-coverage.js
+++ b/scripts/ci-check-shard-coverage.js
@@ -63,10 +63,20 @@ const parseMatrix = (raw) => {
         writeErr(`Could not parse the matrix JSON: ${err.message}`);
         process.exit(2);
     }
-    const shards = matrix.include || [];
-    if (shards.length === 0) {
-        writeErr('The matrix has no shards.');
+    const shards = matrix.include;
+    if (!Array.isArray(shards) || shards.length === 0) {
+        writeErr('The matrix must contain a non-empty "include" array.');
         process.exit(2);
+    }
+    // Fail closed: a missing or non-string `cases` must not be mistaken for the "runs everything"
+    // sentinel below, which would silently switch this guard off on a malformed matrix.
+    for (const shard of shards) {
+        if (typeof shard.cases !== 'string') {
+            writeErr(
+                `Shard "${shard.name || '(unnamed)'}" is missing a string "cases" field; refusing to skip the coverage check.`
+            );
+            process.exit(2);
+        }
     }
     return shards;
 };
@@ -83,8 +93,8 @@ const isExpectedToRun = (file) => {
 function main() {
     const shards = parseMatrix(process.argv[2]);
 
-    // An empty `cases` means "run everything" — nothing can be dropped.
-    if (shards.some((s) => !s.cases)) {
+    // An explicitly empty `cases` means "run everything" — nothing can be dropped.
+    if (shards.some((s) => s.cases === '')) {
         writeOut('A shard runs the whole suite (empty cases); coverage check not applicable.');
         return;
     }

--- a/scripts/ci-check-shard-coverage.js
+++ b/scripts/ci-check-shard-coverage.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/*
+ * Guard the CI shard matrix against silently dropping tests.
+ *
+ * The shard membership in .github/workflows/ci.yml is a hardcoded list of INCLUDE_CASES prefixes.
+ * A newly added test file that nobody adds to a shard would simply never run in RIT's own sharded
+ * pipeline — passing CI while testing nothing. This check fails the build instead.
+ *
+ * Usage: node scripts/ci-check-shard-coverage.js '<matrix json>'
+ *   matrix json: the {"include":[{"name":...,"cases":"a,b,c"}, ...]} object the workflow computes.
+ *
+ * A shard whose `cases` is empty runs the whole suite, so the check is a no-op in that case
+ * (this is how the short suite runs).
+ *
+ * Exits non-zero when an expected-to-run test file is not covered by any shard.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const writeOut = (msg) => process.stdout.write(`${msg}\n`);
+const writeErr = (msg) => process.stderr.write(`${msg}\n`);
+
+const TESTS_DIR = 'tests';
+
+// Files that are intentionally not in any shard because they do not run in the serial suite
+// either. `describe.skip`-ed files are detected automatically and need no entry here.
+const KNOWN_EXCLUSIONS = new Map([
+    [
+        '99_fork_activation/extra/01-activate-latest-fork.js',
+        'inert: the execute() call is commented out (fork activation is opt-in)',
+    ],
+]);
+
+const listTestFiles = (dir, base = dir) => {
+    const out = [];
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            out.push(...listTestFiles(full, base));
+        } else if (entry.isFile() && entry.name.endsWith('.js')) {
+            out.push(path.relative(base, full));
+        }
+    }
+    return out;
+};
+
+// Mirror test.js#needsToBeTested: a pattern matches either the path relative to tests/ or the
+// bare filename.
+const matchesPattern = (relativePath, pattern) =>
+    relativePath.startsWith(pattern) || path.basename(relativePath).startsWith(pattern);
+
+function main() {
+    const raw = process.argv[2];
+    if (!raw) {
+        writeErr('Usage: ci-check-shard-coverage.js <matrix json>');
+        process.exit(2);
+    }
+
+    let matrix;
+    try {
+        matrix = JSON.parse(raw);
+    } catch (err) {
+        writeErr(`Could not parse the matrix JSON: ${err.message}`);
+        process.exit(2);
+    }
+
+    const shards = matrix.include || [];
+    if (shards.length === 0) {
+        writeErr('The matrix has no shards.');
+        process.exit(2);
+    }
+
+    // An empty `cases` means "run everything" — nothing can be dropped.
+    if (shards.some((s) => !s.cases)) {
+        writeOut('A shard runs the whole suite (empty cases); coverage check not applicable.');
+        return;
+    }
+
+    const patterns = shards.flatMap((s) => s.cases.split(',').filter(Boolean));
+    const files = listTestFiles(TESTS_DIR).sort();
+
+    const uncovered = [];
+    for (const file of files) {
+        if (patterns.some((p) => matchesPattern(file, p))) {
+            continue;
+        }
+        // Not in a shard — only acceptable if it does not run in the serial suite either.
+        const source = fs.readFileSync(path.join(TESTS_DIR, file), 'utf8');
+        if (source.includes('describe.skip(')) {
+            continue;
+        }
+        if (KNOWN_EXCLUSIONS.has(file)) {
+            continue;
+        }
+        uncovered.push(file);
+    }
+
+    // A pattern that matches nothing is usually a typo or a renamed/deleted file.
+    const deadPatterns = patterns.filter((p) => !files.some((f) => matchesPattern(f, p)));
+
+    if (uncovered.length > 0 || deadPatterns.length > 0) {
+        for (const file of uncovered) {
+            writeErr(
+                `::error::Test file not assigned to any CI shard: tests/${file} — add it to a shard in .github/workflows/ci.yml`
+            );
+        }
+        for (const pattern of deadPatterns) {
+            writeErr(
+                `::error::Shard pattern matches no test file: "${pattern}" — stale entry in .github/workflows/ci.yml`
+            );
+        }
+        process.exit(1);
+    }
+
+    writeOut(
+        `Shard coverage OK: ${files.length} test file(s), all runnable ones assigned to a shard.`
+    );
+}
+
+main();

--- a/scripts/ci-merge-junit.js
+++ b/scripts/ci-merge-junit.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/*
+ * Merge the per-shard mocha-junit-reporter XML files into one cumulative JUnit report, so the run
+ * has a single <testsuites> document (for the reporting tool, PR annotations, or a download) even
+ * though the suite was executed across several sharded jobs.
+ *
+ * Usage: node scripts/ci-merge-junit.js [input-dir] [output-file]
+ *   input-dir   directory searched recursively for *.xml shard reports (default: shard-reports)
+ *   output-file cumulative report to write                            (default: reports/junit.xml)
+ *
+ * Designed to never fail the job: unreadable/unparsable inputs are skipped, and an empty input set
+ * still produces a valid (empty) <testsuites> document rather than a non-zero exit.
+ *
+ * NOTE: every shard reruns the shared bootstrap (00_sync) on its own chain, so the bootstrap
+ * testsuite appears once per shard in the merged report — the cumulative counts are faithful to
+ * what actually ran, not de-duplicated.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const inputDir = process.argv[2] || 'shard-reports';
+const outFile = process.argv[3] || 'reports/junit.xml';
+
+// mocha-junit-reporter emits a flat list of <testsuite> under one <testsuites> root; match each
+// <testsuite> block (self-closing or with children) with attribute-level regex — no nesting.
+const SUITE_RE = /<testsuite\b[^>]*?(?:\/>|>[\s\S]*?<\/testsuite>)/g;
+
+const getAttr = (fragment, name) => {
+    const match = fragment.match(new RegExp(String.raw`\b${name}="([^"]*)"`));
+    return match ? match[1] : null;
+};
+
+const findReports = (dir) => {
+    const out = [];
+    let entries;
+    try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+        return out; // missing dir -> no reports
+    }
+    for (const entry of entries) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            out.push(...findReports(full));
+        } else if (entry.isFile() && entry.name.endsWith('.xml')) {
+            out.push(full);
+        }
+    }
+    return out;
+};
+
+function main() {
+    const files = findReports(inputDir).sort();
+    const suites = [];
+    const totals = { tests: 0, failures: 0, errors: 0, skipped: 0, time: 0 };
+
+    for (const file of files) {
+        let xml;
+        try {
+            xml = fs.readFileSync(file, 'utf8');
+        } catch {
+            continue; // skip unreadable report
+        }
+        for (const match of xml.matchAll(SUITE_RE)) {
+            const fragment = match[0];
+            suites.push(fragment);
+            totals.tests += Number.parseInt(getAttr(fragment, 'tests') || '0', 10) || 0;
+            totals.failures += Number.parseInt(getAttr(fragment, 'failures') || '0', 10) || 0;
+            totals.errors += Number.parseInt(getAttr(fragment, 'errors') || '0', 10) || 0;
+            totals.skipped += Number.parseInt(getAttr(fragment, 'skipped') || '0', 10) || 0;
+            totals.time += Number.parseFloat(getAttr(fragment, 'time') || '0') || 0;
+        }
+    }
+
+    const root =
+        `<testsuites name="Rootstock Integration Tests (all shards)" ` +
+        `tests="${totals.tests}" failures="${totals.failures}" errors="${totals.errors}" ` +
+        `skipped="${totals.skipped}" time="${totals.time.toFixed(3)}">`;
+    const doc = `<?xml version="1.0" encoding="UTF-8"?>\n${root}\n${suites.join('\n')}\n</testsuites>\n`;
+
+    fs.mkdirSync(path.dirname(path.resolve(outFile)), { recursive: true });
+    fs.writeFileSync(outFile, doc, 'utf8');
+
+    process.stderr.write(
+        `Merged ${files.length} report file(s) -> ${suites.length} testsuite(s), ` +
+            `${totals.tests} tests, ${totals.failures} failures, ${totals.skipped} skipped ` +
+            `into ${outFile}\n`
+    );
+}
+
+main();

--- a/scripts/ci-merge-junit.js
+++ b/scripts/ci-merge-junit.js
@@ -22,6 +22,52 @@ const path = require('node:path');
 const inputDir = process.argv[2] || 'shard-reports';
 const outFile = process.argv[3] || 'reports/junit.xml';
 
+// Paths come from argv, so guard them before any file-system access: resolve against the working
+// directory (which is GITHUB_WORKSPACE in CI, where the reports live) and confirm the canonical
+// path stays inside it. The check is kept inline at each use so a crafted argument that escapes
+// the base is refused before it ever reaches the file system. realpathSync can throw (permissions,
+// broken symlink); fall back to the plain resolved cwd so module load never crashes the step.
+let BASE_DIR;
+try {
+    BASE_DIR = fs.realpathSync(path.resolve(process.cwd()));
+} catch {
+    BASE_DIR = path.resolve(process.cwd());
+}
+
+const safeReadDir = (dir) => {
+    try {
+        const resolved = path.resolve(BASE_DIR, dir);
+        if (resolved !== BASE_DIR && !resolved.startsWith(BASE_DIR + path.sep)) {
+            return [];
+        }
+        return fs.readdirSync(resolved, { withFileTypes: true });
+    } catch {
+        // Never let a directory probe fail the job — treat as "no reports here".
+        return [];
+    }
+};
+
+const safeReadFile = (file) => {
+    try {
+        const resolved = path.resolve(BASE_DIR, file);
+        if (resolved !== BASE_DIR && !resolved.startsWith(BASE_DIR + path.sep)) {
+            return null;
+        }
+        return fs.readFileSync(resolved, 'utf8');
+    } catch {
+        return null;
+    }
+};
+
+const safeWriteFile = (file, contents) => {
+    const resolved = path.resolve(BASE_DIR, file);
+    if (resolved !== BASE_DIR && !resolved.startsWith(BASE_DIR + path.sep)) {
+        throw new Error(`Refusing to write outside the workspace: ${file}`);
+    }
+    fs.mkdirSync(path.dirname(resolved), { recursive: true });
+    fs.writeFileSync(resolved, contents, 'utf8');
+};
+
 // mocha-junit-reporter emits a flat list of <testsuite> under one <testsuites> root; match each
 // <testsuite> block (self-closing or with children) with attribute-level regex — no nesting.
 const SUITE_RE = /<testsuite\b[^>]*?(?:\/>|>[\s\S]*?<\/testsuite>)/g;
@@ -33,13 +79,7 @@ const getAttr = (fragment, name) => {
 
 const findReports = (dir) => {
     const out = [];
-    let entries;
-    try {
-        entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch {
-        return out; // missing dir -> no reports
-    }
-    for (const entry of entries) {
+    for (const entry of safeReadDir(dir)) {
         const full = path.join(dir, entry.name);
         if (entry.isDirectory()) {
             out.push(...findReports(full));
@@ -56,11 +96,9 @@ function main() {
     const totals = { tests: 0, failures: 0, errors: 0, skipped: 0, time: 0 };
 
     for (const file of files) {
-        let xml;
-        try {
-            xml = fs.readFileSync(file, 'utf8');
-        } catch {
-            continue; // skip unreadable report
+        const xml = safeReadFile(file);
+        if (xml === null) {
+            continue; // skip unreadable/out-of-workspace report
         }
         for (const match of xml.matchAll(SUITE_RE)) {
             const fragment = match[0];
@@ -79,8 +117,7 @@ function main() {
         `skipped="${totals.skipped}" time="${totals.time.toFixed(3)}">`;
     const doc = `<?xml version="1.0" encoding="UTF-8"?>\n${root}\n${suites.join('\n')}\n</testsuites>\n`;
 
-    fs.mkdirSync(path.dirname(path.resolve(outFile)), { recursive: true });
-    fs.writeFileSync(outFile, doc, 'utf8');
+    safeWriteFile(outFile, doc);
 
     process.stderr.write(
         `Merged ${files.length} report file(s) -> ${suites.length} testsuite(s), ` +
@@ -89,4 +126,11 @@ function main() {
     );
 }
 
-main();
+try {
+    main();
+} catch (err) {
+    // A refused path (outside the workspace) is a misuse worth failing on, but report it as a
+    // clean message rather than an uncaught stack trace.
+    process.stderr.write(`ci-merge-junit: ${err.message}\n`);
+    process.exit(1);
+}

--- a/scripts/ci-merge-junit.js
+++ b/scripts/ci-merge-junit.js
@@ -8,8 +8,11 @@
  *   input-dir   directory searched recursively for *.xml shard reports (default: shard-reports)
  *   output-file cumulative report to write                            (default: reports/junit.xml)
  *
- * Designed to never fail the job: unreadable/unparsable inputs are skipped, and an empty input set
- * still produces a valid (empty) <testsuites> document rather than a non-zero exit.
+ * Tolerant of bad input: unreadable/unparsable reports are skipped, and an empty input set still
+ * produces a valid (empty) <testsuites> document rather than an error. It does exit non-zero if
+ * the output itself cannot be written (unwritable path, or a path refused for escaping the
+ * workspace) — that is a real failure, not a degraded report. The workflow step that runs this is
+ * `continue-on-error`, so the merge can never turn a passing run red.
  *
  * NOTE: every shard reruns the shared bootstrap (00_sync) on its own chain, so the bootstrap
  * testsuite appears once per shard in the merged report — the cumulative counts are faithful to
@@ -40,7 +43,12 @@ const safeReadDir = (dir) => {
         if (resolved !== BASE_DIR && !resolved.startsWith(BASE_DIR + path.sep)) {
             return [];
         }
-        return fs.readdirSync(resolved, { withFileTypes: true });
+        // realpath too, so a symlink under the (artifact-written) reports dir cannot point outside.
+        const real = fs.realpathSync(resolved);
+        if (real !== BASE_DIR && !real.startsWith(BASE_DIR + path.sep)) {
+            return [];
+        }
+        return fs.readdirSync(real, { withFileTypes: true });
     } catch {
         // Never let a directory probe fail the job — treat as "no reports here".
         return [];
@@ -53,7 +61,11 @@ const safeReadFile = (file) => {
         if (resolved !== BASE_DIR && !resolved.startsWith(BASE_DIR + path.sep)) {
             return null;
         }
-        return fs.readFileSync(resolved, 'utf8');
+        const real = fs.realpathSync(resolved);
+        if (real !== BASE_DIR && !real.startsWith(BASE_DIR + path.sep)) {
+            return null;
+        }
+        return fs.readFileSync(real, 'utf8');
     } catch {
         return null;
     }
@@ -64,8 +76,15 @@ const safeWriteFile = (file, contents) => {
     if (resolved !== BASE_DIR && !resolved.startsWith(BASE_DIR + path.sep)) {
         throw new Error(`Refusing to write outside the workspace: ${file}`);
     }
-    fs.mkdirSync(path.dirname(resolved), { recursive: true });
-    fs.writeFileSync(resolved, contents, 'utf8');
+    // Create the directory first, then re-check its canonical path: a symlinked output dir
+    // (e.g. reports -> /tmp) would otherwise pass the prefix check above and escape the workspace.
+    const dir = path.dirname(resolved);
+    fs.mkdirSync(dir, { recursive: true });
+    const realDir = fs.realpathSync(dir);
+    if (realDir !== BASE_DIR && !realDir.startsWith(BASE_DIR + path.sep)) {
+        throw new Error(`Refusing to follow a symlink outside the workspace: ${file}`);
+    }
+    fs.writeFileSync(path.join(realDir, path.basename(resolved)), contents, 'utf8');
 };
 
 // mocha-junit-reporter emits a flat list of <testsuite> under one <testsuites> root; match each


### PR DESCRIPTION
This pull request significantly refactors the CI workflow in `.github/workflows/ci.yml` to introduce sharded test execution, improve artifact reuse, and streamline reporting and notifications. The main improvements are the addition of a build-and-prepare stage that shards the test suite, runs each shard in parallel, and aggregates results for a single status and notification. This change aims to reduce redundant work and make CI runs faster and more reliable.

Key changes include:

**Sharded Test Execution and Preparation**
* Added a `prepare` job that builds the Docker image and test jar once, computes the test shard matrix, and uploads the jar as an artifact for all shards to reuse. This avoids rebuilding the environment for each shard, significantly speeding up CI runs.
* The test suite is now split into shards based on a matrix, with each shard running a subset of tests in parallel. The matrix is determined dynamically in the `prepare` job.

**Test Execution and Reporting**
* The `test-container-action` job now consumes the prebuilt jar and runs only its assigned test cases, uploading individual JUnit reports and timing summaries. Test failures are surfaced as PR annotations, and each shard reports its results independently.
* Introduced an `aggregate` job that collects all shard reports, merges them into a single cumulative JUnit report, and gates the overall CI status on all shards passing. This job also generates a consolidated timing summary.

**Notification and Publishing Improvements**
* Slack notifications for success and failure are now explicitly gated on the aggregate job’s result, ensuring notifications are sent even if earlier jobs fail. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL225-R427) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL261-R467)
* The image publishing job now depends on the aggregate job (not just the test job), ensuring the image is only published if all shards and the build pass.
* Updated cache usage and comments to reflect the new flow, ensuring Docker layers are reused efficiently across jobs.

These changes make the CI pipeline more modular, efficient, and reliable, especially as the test suite grows.